### PR TITLE
Add dark/light mode, fix mobile nav, fix contact form, style hero name

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,13 @@
 @tailwind utilities;
 
 :root {
+  --bg-primary: #ffffff;
+  --scrollbar-track: #f1f5f9;
+}
+
+.dark {
   --bg-primary: #050816;
+  --scrollbar-track: #050816;
 }
 
 * {
@@ -20,20 +26,15 @@ body {
   background: var(--bg-primary);
   color: #e2e8f0;
   overflow-x: hidden;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
-::-webkit-scrollbar {
-  width: 5px;
-}
-::-webkit-scrollbar-track {
-  background: #050816;
-}
-::-webkit-scrollbar-thumb {
-  background: #6366f1;
-  border-radius: 10px;
+html:not(.dark) body {
+  color: #0f172a;
 }
 
-::selection {
-  background: #6366f1;
-  color: white;
-}
+::-webkit-scrollbar { width: 5px; }
+::-webkit-scrollbar-track { background: var(--scrollbar-track); }
+::-webkit-scrollbar-thumb { background: #6366f1; border-radius: 10px; }
+
+::selection { background: #6366f1; color: white; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { ThemeProvider } from 'next-themes'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -12,9 +13,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="scroll-smooth">
-      <body className={`${inter.className} bg-[#050816] text-slate-100 overflow-x-hidden`}>
-        {children}
+    <html lang="en" className="scroll-smooth" suppressHydrationWarning>
+      <body className={`${inter.className} overflow-x-hidden`}>
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -34,15 +34,15 @@ export default function About() {
             animate={isInView ? { opacity: 1, x: 0 } : {}}
             transition={{ duration: 0.6, delay: 0.2 }}
           >
-            <p className="text-slate-400 leading-relaxed text-lg">
+            <p className="text-slate-600 dark:text-slate-400 leading-relaxed text-lg">
               I am a versatile software engineer with{' '}
-              <span className="text-indigo-400 font-medium">4+ years</span> of industry experience,
+              <span className="text-indigo-500 dark:text-indigo-400 font-medium">4+ years</span> of industry experience,
               having successfully delivered complex technical projects utilizing a variety of
               technologies across{' '}
-              <span className="text-indigo-400 font-medium">front-end</span> and{' '}
-              <span className="text-indigo-400 font-medium">back-end</span> development.
+              <span className="text-indigo-500 dark:text-indigo-400 font-medium">front-end</span> and{' '}
+              <span className="text-indigo-500 dark:text-indigo-400 font-medium">back-end</span> development.
             </p>
-            <p className="text-slate-400 leading-relaxed text-lg mt-4">
+            <p className="text-slate-600 dark:text-slate-400 leading-relaxed text-lg mt-4">
               As a collaborative team member and effective problem solver, I am seeking an opportunity
               to contribute to a challenging environment where I can apply my skills and further my
               professional growth.
@@ -66,7 +66,7 @@ export default function About() {
                 initial={{ opacity: 0, scale: 0.9 }}
                 animate={isInView ? { opacity: 1, scale: 1 } : {}}
                 transition={{ duration: 0.4, delay: 0.4 + i * 0.08 }}
-                className="p-6 rounded-xl bg-white/5 border border-white/10 hover:border-indigo-500/40 hover:bg-white/[0.07] transition-all duration-300"
+                className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 transition-all duration-300"
               >
                 <p className="text-4xl font-bold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
                   {stat.value}

--- a/components/Certifications.tsx
+++ b/components/Certifications.tsx
@@ -11,18 +11,8 @@ const certifications = [
     meta: 'August 2018 · Certificate ID: 180-177-776',
     icon: '🏅',
   },
-  {
-    name: 'Python Bootcamp',
-    issuer: 'Udemy',
-    meta: '',
-    icon: '🐍',
-  },
-  {
-    name: 'Complete React Developer',
-    issuer: 'Udemy',
-    meta: '',
-    icon: '⚛️',
-  },
+  { name: 'Python Bootcamp', issuer: 'Udemy', meta: '', icon: '🐍' },
+  { name: 'Complete React Developer', issuer: 'Udemy', meta: '', icon: '⚛️' },
 ]
 
 export default function Certifications() {
@@ -30,7 +20,7 @@ export default function Certifications() {
   const isInView = useInView(ref, { once: true, margin: '-100px' })
 
   return (
-    <section className="py-24 px-4 bg-white/[0.02]">
+    <section className="py-24 px-4 bg-black/[0.02] dark:bg-white/[0.02]">
       <div className="max-w-5xl mx-auto" ref={ref}>
         <motion.div
           initial={{ opacity: 0, y: 40 }}
@@ -48,14 +38,13 @@ export default function Certifications() {
               initial={{ opacity: 0, x: -30 }}
               animate={isInView ? { opacity: 1, x: 0 } : {}}
               transition={{ duration: 0.5, delay: i * 0.1 }}
-              className="flex items-center gap-4 p-5 rounded-xl bg-white/5 border border-white/10 hover:border-indigo-500/30 hover:bg-white/[0.07] transition-all duration-300"
+              className="flex items-center gap-4 p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/30 transition-all duration-300"
             >
               <span className="text-3xl">{cert.icon}</span>
               <div>
-                <p className="text-white font-medium">{cert.name}</p>
+                <p className="text-slate-900 dark:text-white font-medium">{cert.name}</p>
                 <p className="text-slate-500 text-sm mt-0.5">
-                  {cert.issuer}
-                  {cert.meta && ` · ${cert.meta}`}
+                  {cert.issuer}{cert.meta && ` · ${cert.meta}`}
                 </p>
               </div>
             </motion.div>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,12 +1,37 @@
 'use client'
 
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { motion, useInView } from 'framer-motion'
 import SectionHeading from './SectionHeading'
+
+type Status = 'idle' | 'sending' | 'success' | 'error'
 
 export default function Contact() {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-100px' })
+  const [status, setStatus] = useState<Status>('idle')
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setStatus('sending')
+    const form = e.currentTarget
+    const data = new FormData(form)
+    try {
+      const res = await fetch('https://formspree.io/f/mvgkgdal', {
+        method: 'POST',
+        body: data,
+        headers: { Accept: 'application/json' },
+      })
+      if (res.ok) {
+        setStatus('success')
+        form.reset()
+      } else {
+        setStatus('error')
+      }
+    } catch {
+      setStatus('error')
+    }
+  }
 
   return (
     <section id="contact" className="py-24 px-4">
@@ -24,7 +49,7 @@ export default function Contact() {
           initial={{ opacity: 0, y: 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.5, delay: 0.15 }}
-          className="text-slate-400 text-lg leading-relaxed mb-10"
+          className="text-slate-500 dark:text-slate-400 text-lg leading-relaxed mb-10"
         >
           I&apos;m currently open to new opportunities. Whether you have a question or just want
           to say hi — my inbox is always open!
@@ -34,45 +59,59 @@ export default function Contact() {
           initial={{ opacity: 0, y: 30 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, delay: 0.25 }}
-          className="p-8 rounded-2xl bg-white/5 border border-white/10"
+          className="p-8 rounded-2xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10"
         >
-          <form
-            method="POST"
-            action="https://formspree.io/f/mvgkgdal"
-            className="space-y-5"
-          >
-            <input type="hidden" name="_subject" value="Contact request from portfolio" />
-            <div>
-              <label className="block text-slate-400 text-sm mb-1.5 font-medium">
-                Your Email
-              </label>
-              <input
-                type="email"
-                name="_replyto"
-                required
-                placeholder="hello@example.com"
-                className="w-full px-4 py-3 rounded-lg bg-white/10 border border-white/10 text-white placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500/50 transition-all"
-              />
+          {status === 'success' ? (
+            <div className="text-center py-8">
+              <div className="text-4xl mb-4">🎉</div>
+              <p className="text-slate-900 dark:text-white font-semibold text-lg">Message sent!</p>
+              <p className="text-slate-500 dark:text-slate-400 mt-2">Thanks for reaching out. I&apos;ll get back to you soon.</p>
+              <button
+                onClick={() => setStatus('idle')}
+                className="mt-6 px-5 py-2 text-sm text-indigo-400 border border-indigo-500/30 rounded-lg hover:bg-indigo-500/10 transition-all"
+              >
+                Send another
+              </button>
             </div>
-            <div>
-              <label className="block text-slate-400 text-sm mb-1.5 font-medium">
-                Message
-              </label>
-              <textarea
-                name="message"
-                required
-                rows={5}
-                placeholder="Your message..."
-                className="w-full px-4 py-3 rounded-lg bg-white/10 border border-white/10 text-white placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500/50 transition-all resize-none"
-              />
-            </div>
-            <button
-              type="submit"
-              className="w-full py-3.5 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg font-medium transition-all duration-300 hover:shadow-xl hover:shadow-indigo-500/30 hover:-translate-y-0.5 active:translate-y-0"
-            >
-              Send Message
-            </button>
-          </form>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <input type="hidden" name="_subject" value="Contact request from portfolio" />
+              <div>
+                <label className="block text-slate-500 dark:text-slate-400 text-sm mb-1.5 font-medium">
+                  Your Email
+                </label>
+                <input
+                  type="email"
+                  name="_replyto"
+                  required
+                  placeholder="hello@example.com"
+                  className="w-full px-4 py-3 rounded-lg bg-black/5 dark:bg-white/10 border border-black/10 dark:border-white/10 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500/50 transition-all"
+                />
+              </div>
+              <div>
+                <label className="block text-slate-500 dark:text-slate-400 text-sm mb-1.5 font-medium">
+                  Message
+                </label>
+                <textarea
+                  name="message"
+                  required
+                  rows={5}
+                  placeholder="Your message..."
+                  className="w-full px-4 py-3 rounded-lg bg-black/5 dark:bg-white/10 border border-black/10 dark:border-white/10 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500/50 transition-all resize-none"
+                />
+              </div>
+              {status === 'error' && (
+                <p className="text-red-400 text-sm">Something went wrong. Please try again.</p>
+              )}
+              <button
+                type="submit"
+                disabled={status === 'sending'}
+                className="w-full py-3.5 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-60 disabled:cursor-wait text-white rounded-lg font-medium transition-all duration-300 hover:shadow-xl hover:shadow-indigo-500/30 hover:-translate-y-0.5 active:translate-y-0"
+              >
+                {status === 'sending' ? 'Sending…' : 'Send Message'}
+              </button>
+            </form>
+          )}
         </motion.div>
       </div>
     </section>

--- a/components/Education.tsx
+++ b/components/Education.tsx
@@ -40,15 +40,15 @@ export default function Education() {
               initial={{ opacity: 0, y: 30 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.5, delay: i * 0.15 }}
-              className="p-6 rounded-xl bg-white/5 border border-white/10 hover:border-indigo-500/30 hover:bg-white/[0.07] transition-all duration-300 group"
+              className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/30 transition-all duration-300 group"
             >
               <div className="flex items-start gap-4">
                 <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-indigo-500/20 to-purple-500/20 border border-indigo-500/30 flex items-center justify-center text-2xl flex-shrink-0 group-hover:scale-110 transition-transform duration-300">
                   🎓
                 </div>
                 <div>
-                  <h3 className="text-white font-semibold leading-snug">{edu.school}</h3>
-                  <p className="text-indigo-400 text-sm font-medium mt-1.5">{edu.degree}</p>
+                  <h3 className="text-slate-900 dark:text-white font-semibold leading-snug">{edu.school}</h3>
+                  <p className="text-indigo-500 dark:text-indigo-400 text-sm font-medium mt-1.5">{edu.degree}</p>
                   <p className="text-slate-500 text-xs font-mono mt-2">{edu.date}</p>
                 </div>
               </div>

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -36,19 +36,11 @@ const experiences = [
     date: 'January 2019 – June 2019',
     gradient: 'from-emerald-500 to-teal-500',
     dot: 'bg-emerald-500',
-    bullets: [
-      'Developed applications using Django and related Python technologies',
-    ],
+    bullets: ['Developed applications using Django and related Python technologies'],
   },
 ]
 
-function ExperienceItem({
-  exp,
-  index,
-}: {
-  exp: (typeof experiences)[0]
-  index: number
-}) {
+function ExperienceItem({ exp, index }: { exp: (typeof experiences)[0]; index: number }) {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-80px' })
 
@@ -60,29 +52,25 @@ function ExperienceItem({
       transition={{ duration: 0.5, delay: index * 0.12 }}
       className="relative pl-10 pb-12 last:pb-0"
     >
-      <div className="absolute left-0 top-3 bottom-0 w-px bg-gradient-to-b from-white/10 to-transparent" />
-      <div
-        className={`absolute left-0 top-2.5 -translate-x-[5px] w-2.5 h-2.5 rounded-full ${exp.dot} shadow-lg`}
-      />
+      <div className="absolute left-0 top-3 bottom-0 w-px bg-gradient-to-b from-black/10 dark:from-white/10 to-transparent" />
+      <div className={`absolute left-0 top-2.5 -translate-x-[5px] w-2.5 h-2.5 rounded-full ${exp.dot} shadow-lg`} />
 
-      <div className="p-6 rounded-xl bg-white/5 border border-white/10 hover:border-white/20 hover:bg-white/[0.07] transition-all duration-300">
+      <div className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 transition-all duration-300">
         <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
           <div>
-            <h3 className="text-xl font-semibold text-white">{exp.company}</h3>
-            <p
-              className={`text-sm font-medium mt-0.5 bg-gradient-to-r ${exp.gradient} bg-clip-text text-transparent`}
-            >
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{exp.company}</h3>
+            <p className={`text-sm font-medium mt-0.5 bg-gradient-to-r ${exp.gradient} bg-clip-text text-transparent`}>
               {exp.role}
             </p>
           </div>
-          <span className="text-xs text-slate-500 font-mono bg-white/5 border border-white/10 px-3 py-1 rounded-full whitespace-nowrap">
+          <span className="text-xs text-slate-500 font-mono bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 px-3 py-1 rounded-full whitespace-nowrap">
             {exp.date}
           </span>
         </div>
         <ul className="space-y-2">
           {exp.bullets.map((bullet, i) => (
-            <li key={i} className="flex gap-3 text-slate-400 text-sm leading-relaxed">
-              <span className="text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
+            <li key={i} className="flex gap-3 text-slate-600 dark:text-slate-400 text-sm leading-relaxed">
+              <span className="text-indigo-500 dark:text-indigo-400 mt-0.5 flex-shrink-0">▸</span>
               {bullet}
             </li>
           ))}
@@ -97,7 +85,7 @@ export default function Experience() {
   const isInView = useInView(ref, { once: true, margin: '-100px' })
 
   return (
-    <section id="experience" className="py-24 px-4 bg-white/[0.02]">
+    <section id="experience" className="py-24 px-4 bg-black/[0.02] dark:bg-white/[0.02]">
       <div className="max-w-4xl mx-auto" ref={ref}>
         <motion.div
           initial={{ opacity: 0, y: 40 }}
@@ -107,7 +95,6 @@ export default function Experience() {
         >
           <SectionHeading number="02" title="Experience" />
         </motion.div>
-
         <div>
           {experiences.map((exp, i) => (
             <ExperienceItem key={exp.company} exp={exp} index={i} />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,33 +1,17 @@
 import { FaGithub, FaLinkedin, FaStackOverflow, FaFacebook } from 'react-icons/fa'
 
 const socialLinks = [
-  {
-    icon: FaGithub,
-    href: 'https://github.com/SurajFc',
-    label: 'GitHub',
-  },
-  {
-    icon: FaLinkedin,
-    href: 'https://www.linkedin.com/in/suraj4/',
-    label: 'LinkedIn',
-  },
-  {
-    icon: FaStackOverflow,
-    href: 'https://stackoverflow.com/users/12359814/surajfc',
-    label: 'Stack Overflow',
-  },
-  {
-    icon: FaFacebook,
-    href: 'https://www.facebook.com/surajthapafc/',
-    label: 'Facebook',
-  },
+  { icon: FaGithub, href: 'https://github.com/SurajFc', label: 'GitHub' },
+  { icon: FaLinkedin, href: 'https://www.linkedin.com/in/suraj4/', label: 'LinkedIn' },
+  { icon: FaStackOverflow, href: 'https://stackoverflow.com/users/12359814/surajfc', label: 'Stack Overflow' },
+  { icon: FaFacebook, href: 'https://www.facebook.com/surajthapafc/', label: 'Facebook' },
 ]
 
 export default function Footer() {
   return (
-    <footer className="py-8 px-4 border-t border-white/5">
+    <footer className="py-8 px-4 border-t border-black/5 dark:border-white/5">
       <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
-        <p className="text-slate-600 text-sm">
+        <p className="text-slate-500 text-sm">
           © {new Date().getFullYear()} Suraj Thapa. All rights reserved.
         </p>
         <div className="flex items-center gap-5">
@@ -38,7 +22,7 @@ export default function Footer() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label={link.label}
-              className="text-slate-600 hover:text-indigo-400 transition-colors text-xl"
+              className="text-slate-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors text-xl"
             >
               <link.icon />
             </a>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { useTheme } from 'next-themes'
+import { HiSun, HiMoon } from 'react-icons/hi'
 
 const navLinks = [
   { name: 'About', href: '#about' },
@@ -16,6 +18,10 @@ export default function Header() {
   const [scrolled, setScrolled] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [activeSection, setActiveSection] = useState('')
+  const { theme, setTheme, resolvedTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => { setMounted(true) }, [])
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 50)
@@ -38,6 +44,19 @@ export default function Header() {
     return () => observers.forEach((o) => o?.disconnect())
   }, [])
 
+  // Smooth scroll + close menu — prevents default anchor jump on mobile
+  const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
+    e.preventDefault()
+    setMenuOpen(false)
+    const id = href.replace('#', '')
+    // Small delay lets the menu close animation start before scroll
+    setTimeout(() => {
+      document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' })
+    }, 150)
+  }
+
+  const isDark = resolvedTheme === 'dark'
+
   return (
     <motion.header
       initial={{ y: -80, opacity: 0 }}
@@ -45,7 +64,7 @@ export default function Header() {
       transition={{ duration: 0.6, ease: 'easeOut' }}
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
         scrolled
-          ? 'bg-[#050816]/80 backdrop-blur-md border-b border-white/5 shadow-lg shadow-black/20'
+          ? 'bg-white/80 dark:bg-[#050816]/80 backdrop-blur-md border-b border-black/5 dark:border-white/5 shadow-lg shadow-black/5 dark:shadow-black/20'
           : ''
       }`}
     >
@@ -58,15 +77,17 @@ export default function Header() {
             ST
           </a>
 
+          {/* Desktop nav */}
           <nav className="hidden md:flex items-center gap-8">
             {navLinks.map((link) => (
               <a
                 key={link.name}
                 href={link.href}
+                onClick={(e) => handleNavClick(e, link.href)}
                 className={`text-sm font-medium transition-colors duration-200 ${
                   activeSection === link.href.slice(1)
                     ? 'text-indigo-400'
-                    : 'text-slate-400 hover:text-white'
+                    : 'text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white'
                 }`}
               >
                 {link.name}
@@ -74,27 +95,42 @@ export default function Header() {
             ))}
           </nav>
 
-          <button
-            onClick={() => setMenuOpen(!menuOpen)}
-            className="md:hidden flex flex-col gap-1.5 p-1"
-            aria-label="Toggle menu"
-          >
-            <motion.span
-              animate={menuOpen ? { rotate: 45, y: 8 } : { rotate: 0, y: 0 }}
-              className="block w-6 h-0.5 bg-slate-400"
-            />
-            <motion.span
-              animate={menuOpen ? { opacity: 0 } : { opacity: 1 }}
-              className="block w-6 h-0.5 bg-slate-400"
-            />
-            <motion.span
-              animate={menuOpen ? { rotate: -45, y: -8 } : { rotate: 0, y: 0 }}
-              className="block w-6 h-0.5 bg-slate-400"
-            />
-          </button>
+          <div className="flex items-center gap-3">
+            {/* Theme toggle */}
+            {mounted && (
+              <button
+                onClick={() => setTheme(isDark ? 'light' : 'dark')}
+                aria-label="Toggle theme"
+                className="p-2 rounded-lg text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 transition-all duration-200"
+              >
+                {isDark ? <HiSun className="w-5 h-5" /> : <HiMoon className="w-5 h-5" />}
+              </button>
+            )}
+
+            {/* Hamburger */}
+            <button
+              onClick={() => setMenuOpen(!menuOpen)}
+              className="md:hidden flex flex-col gap-1.5 p-1"
+              aria-label="Toggle menu"
+            >
+              <motion.span
+                animate={menuOpen ? { rotate: 45, y: 8 } : { rotate: 0, y: 0 }}
+                className="block w-6 h-0.5 bg-slate-500 dark:bg-slate-400"
+              />
+              <motion.span
+                animate={menuOpen ? { opacity: 0 } : { opacity: 1 }}
+                className="block w-6 h-0.5 bg-slate-500 dark:bg-slate-400"
+              />
+              <motion.span
+                animate={menuOpen ? { rotate: -45, y: -8 } : { rotate: 0, y: 0 }}
+                className="block w-6 h-0.5 bg-slate-500 dark:bg-slate-400"
+              />
+            </button>
+          </div>
         </div>
       </div>
 
+      {/* Mobile menu */}
       <AnimatePresence>
         {menuOpen && (
           <motion.div
@@ -102,18 +138,18 @@ export default function Header() {
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
             transition={{ duration: 0.2 }}
-            className="md:hidden bg-[#0d0d1a]/95 backdrop-blur-md border-b border-white/5"
+            className="md:hidden bg-white/95 dark:bg-[#0d0d1a]/95 backdrop-blur-md border-b border-black/5 dark:border-white/5 overflow-hidden"
           >
             <nav className="flex flex-col py-4 px-6 gap-1">
               {navLinks.map((link) => (
                 <a
                   key={link.name}
                   href={link.href}
-                  onClick={() => setMenuOpen(false)}
-                  className={`py-2.5 text-sm font-medium transition-colors ${
+                  onClick={(e) => handleNavClick(e, link.href)}
+                  className={`py-3 text-sm font-medium transition-colors ${
                     activeSection === link.href.slice(1)
                       ? 'text-indigo-400'
-                      : 'text-slate-400 hover:text-white'
+                      : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white'
                   }`}
                 >
                   {link.name}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -18,8 +18,6 @@ export default function Hero() {
     )
   }, [])
 
-  const name = 'Suraj Thapa'
-
   return (
     <section
       id="home"
@@ -50,15 +48,24 @@ export default function Hero() {
 
         <h1
           ref={nameRef}
-          aria-label={name}
+          aria-label="Suraj Thapa"
           className="text-6xl md:text-8xl lg:text-9xl font-bold mb-4 overflow-hidden leading-none"
         >
-          {name.split('').map((char, i) => (
+          {'Suraj'.split('').map((char, i) => (
             <span
-              key={i}
+              key={`s-${i}`}
               className="char inline-block bg-gradient-to-b from-white to-slate-400 bg-clip-text text-transparent"
             >
-              {char === ' ' ? ' ' : char}
+              {char}
+            </span>
+          ))}
+          <span className="char inline-block">&nbsp;</span>
+          {'Thapa'.split('').map((char, i) => (
+            <span
+              key={`t-${i}`}
+              className="char inline-block bg-gradient-to-br from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent"
+            >
+              {char}
             </span>
           ))}
         </h1>

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -64,7 +64,7 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
       animate={isInView ? { opacity: 1, y: 0 } : {}}
       transition={{ duration: 0.5, delay: (index % 2) * 0.15 }}
       whileHover={{ y: -6 }}
-      className={`group rounded-2xl overflow-hidden bg-white/5 border border-white/10 ${project.border} transition-all duration-300 shadow-xl ${project.glow}`}
+      className={`group rounded-2xl overflow-hidden bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 ${project.border} transition-all duration-300 shadow-xl ${project.glow}`}
     >
       <div className="relative h-52 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent z-10 group-hover:opacity-60 transition-opacity duration-300" />
@@ -78,8 +78,8 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
       </div>
 
       <div className="p-6">
-        <h3 className="text-xl font-semibold text-white mb-2">{project.title}</h3>
-        <p className="text-slate-400 text-sm leading-relaxed mb-4">{project.description}</p>
+        <h3 className="text-xl font-semibold text-slate-900 dark:text-white mb-2">{project.title}</h3>
+        <p className="text-slate-600 dark:text-slate-400 text-sm leading-relaxed mb-4">{project.description}</p>
         <div className="flex flex-wrap gap-2 mb-5">
           {project.tech.map((t) => (
             <span

--- a/components/SectionHeading.tsx
+++ b/components/SectionHeading.tsx
@@ -7,7 +7,7 @@ export default function SectionHeading({ number, title }: Props) {
   return (
     <div className="flex items-center gap-3">
       <span className="text-indigo-400 font-mono text-sm tracking-widest">{number}.</span>
-      <h2 className="text-3xl md:text-4xl font-bold text-white">{title}</h2>
+      <h2 className="text-3xl md:text-4xl font-bold text-slate-900 dark:text-white">{title}</h2>
       <div className="flex-1 h-px bg-gradient-to-r from-indigo-500/40 to-transparent ml-4 hidden sm:block" />
     </div>
   )

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -8,25 +8,25 @@ const skillCategories = [
   {
     name: 'Frontend',
     dot: 'bg-blue-400',
-    badge: 'bg-blue-500/10 text-blue-300 border-blue-500/20',
+    badge: 'bg-blue-500/10 text-blue-600 dark:text-blue-300 border-blue-500/20',
     skills: ['JavaScript', 'TypeScript', 'React', 'React Native', 'Vue.js', 'HTML', 'CSS', 'Redux'],
   },
   {
     name: 'Backend',
     dot: 'bg-purple-400',
-    badge: 'bg-purple-500/10 text-purple-300 border-purple-500/20',
+    badge: 'bg-purple-500/10 text-purple-600 dark:text-purple-300 border-purple-500/20',
     skills: ['Python', 'Django', 'NestJS', 'Node.js', 'GraphQL'],
   },
   {
     name: 'Databases',
     dot: 'bg-emerald-400',
-    badge: 'bg-emerald-500/10 text-emerald-300 border-emerald-500/20',
+    badge: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300 border-emerald-500/20',
     skills: ['PostgreSQL', 'MySQL', 'MongoDB'],
   },
   {
     name: 'Tools & Platforms',
     dot: 'bg-orange-400',
-    badge: 'bg-orange-500/10 text-orange-300 border-orange-500/20',
+    badge: 'bg-orange-500/10 text-orange-600 dark:text-orange-300 border-orange-500/20',
     skills: ['AWS', 'Git/GitHub', 'Figma', 'Jira', 'Postman', 'Confluence', 'Stripe', 'Twilio'],
   },
 ]
@@ -54,11 +54,11 @@ export default function Skills() {
               initial={{ opacity: 0, y: 30 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.5, delay: catIndex * 0.1 }}
-              className="p-6 rounded-xl bg-white/5 border border-white/10 hover:border-white/20 transition-all duration-300"
+              className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 transition-all duration-300"
             >
               <div className="flex items-center gap-2 mb-4">
                 <div className={`w-2.5 h-2.5 rounded-full ${cat.dot}`} />
-                <h3 className="text-white font-semibold">{cat.name}</h3>
+                <h3 className="text-slate-900 dark:text-white font-semibold">{cat.name}</h3>
               </div>
               <div className="flex flex-wrap gap-2">
                 {cat.skills.map((skill, i) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "framer-motion": "^11.3.8",
         "gsap": "^3.12.5",
         "next": "14.2.5",
+        "next-themes": "^0.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.2.1"
@@ -5042,6 +5043,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -8,25 +8,26 @@
     "start": "next start"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.1",
     "@react-pdf/renderer": "^3.4.5",
-    "next": "14.2.5",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "clsx": "^2.1.1",
     "framer-motion": "^11.3.8",
     "gsap": "^3.12.5",
-    "@gsap/react": "^2.1.1",
-    "react-icons": "^5.2.1",
-    "clsx": "^2.1.1"
+    "next": "14.2.5",
+    "next-themes": "^0.4.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-icons": "^5.2.1"
   },
   "devDependencies": {
     "@types/node": "^20.14.9",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "typescript": "^5.5.3",
-    "tailwindcss": "^3.4.6",
     "autoprefixer": "^10.4.19",
-    "postcss": "^8.4.39",
     "eslint": "^8",
-    "eslint-config-next": "14.2.5"
+    "eslint-config-next": "14.2.5",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.6",
+    "typescript": "^5.5.3"
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary

- **Dark/light mode toggle** — Sun/Moon button in the header; defaults to dark, persists via `next-themes`. All components updated with `dark:` Tailwind variants for backgrounds, borders, and text
- **Mobile menu nav fix** — Replaced native anchor jumps with `e.preventDefault()` + `scrollIntoView` after a 150ms delay, so the menu close animation completes before scrolling
- **Contact form fix** — Removed `method/action` redirect to Formspree page; now submits via `fetch` with `Accept: application/json`. Shows inline Sending → Success → Error states with no page navigation
- **Hero name styling** — "Suraj" keeps the white-to-slate gradient; "Thapa" gets a vibrant indigo → purple → pink gradient. GSAP character animation applies to both

## Test plan

- [ ] Toggle dark/light mode — all sections should switch cleanly
- [ ] On mobile: open menu, tap a nav link — menu closes and page scrolls to the correct section
- [ ] Submit the contact form — should show "Sending…" then a success screen without leaving the page
- [ ] Hero: "Suraj" is white/slate, "Thapa" is indigo-purple-pink with GSAP animation on both

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_