### PR TITLE
Add portfolio enhancements: scroll progress, typewriter, profile photo, GitHub activity, SEO

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,44 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import { ThemeProvider } from 'next-themes'
+import ScrollProgress from '@/components/ScrollProgress'
+import BackToTop from '@/components/BackToTop'
+import CursorSpotlight from '@/components/CursorSpotlight'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
 
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
+
 export const metadata: Metadata = {
+  metadataBase: new URL('https://surajfc.github.io'),
   title: 'Suraj Thapa | Software Engineer',
-  description: 'Portfolio of Suraj Thapa — Software Engineer with 4+ years of full-stack experience.',
-  icons: { icon: `${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/favicon.ico` },
+  description:
+    'Portfolio of Suraj Thapa — Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, and more.',
+  icons: { icon: `${BASE}/favicon.ico` },
+  openGraph: {
+    title: 'Suraj Thapa | Software Engineer',
+    description:
+      'Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, NestJS and more.',
+    url: 'https://surajfc.github.io/surajPortfolio/',
+    siteName: 'Suraj Thapa Portfolio',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE}/images/profile.png`,
+        width: 800,
+        height: 800,
+        alt: 'Suraj Thapa',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Suraj Thapa | Software Engineer',
+    description:
+      'Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, NestJS and more.',
+    images: [`${BASE}/images/profile.png`],
+  },
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -16,7 +46,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className="scroll-smooth" suppressHydrationWarning>
       <body className={`${inter.className} overflow-x-hidden`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+          <ScrollProgress />
+          <CursorSpotlight />
           {children}
+          <BackToTop />
         </ThemeProvider>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -68,7 +68,10 @@ export const metadata: Metadata = {
       'Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, NestJS and more. Available for new opportunities.',
     url: SITE_URL,
     siteName: 'Suraj Thapa Portfolio',
-    type: 'website',
+    type: 'profile',
+    firstName: 'Suraj',
+    lastName: 'Thapa',
+    username: 'SurajFc',
     locale: 'en_US',
     images: [
       {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,41 +9,120 @@ import './globals.css'
 const inter = Inter({ subsets: ['latin'] })
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
+const SITE_URL = 'https://surajfc.github.io/surajPortfolio'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://surajfc.github.io'),
-  title: 'Suraj Thapa | Software Engineer',
+
+  title: {
+    default: 'Suraj Thapa | Software Engineer',
+    template: '%s | Suraj Thapa',
+  },
   description:
-    'Portfolio of Suraj Thapa — Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, and more.',
-  icons: { icon: `${BASE}/favicon.ico` },
+    'Portfolio of Suraj Thapa — Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, NestJS, and more. Available for new opportunities.',
+
+  keywords: [
+    'Suraj Thapa',
+    'Software Engineer',
+    'Full Stack Developer',
+    'React Developer',
+    'TypeScript',
+    'Django',
+    'NestJS',
+    'Portfolio',
+    'Frontend Developer',
+    'Backend Developer',
+    'React Native',
+    'GraphQL',
+    'Node.js',
+  ],
+
+  authors: [{ name: 'Suraj Thapa', url: SITE_URL }],
+  creator: 'Suraj Thapa',
+  publisher: 'Suraj Thapa',
+
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+
+  alternates: {
+    canonical: SITE_URL,
+  },
+
+  icons: {
+    icon: `${BASE}/favicon.ico`,
+    shortcut: `${BASE}/favicon.ico`,
+  },
+
   openGraph: {
     title: 'Suraj Thapa | Software Engineer',
     description:
-      'Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, NestJS and more.',
-    url: 'https://surajfc.github.io/surajPortfolio/',
+      'Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, NestJS and more. Available for new opportunities.',
+    url: SITE_URL,
     siteName: 'Suraj Thapa Portfolio',
     type: 'website',
+    locale: 'en_US',
     images: [
       {
         url: `${BASE}/images/profile.png`,
         width: 800,
         height: 800,
-        alt: 'Suraj Thapa',
+        alt: 'Suraj Thapa — Software Engineer',
       },
     ],
   },
+
   twitter: {
     card: 'summary_large_image',
     title: 'Suraj Thapa | Software Engineer',
     description:
       'Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, NestJS and more.',
+    creator: '@surajfc',
     images: [`${BASE}/images/profile.png`],
   },
+
+  category: 'technology',
+}
+
+// JSON-LD structured data — helps Google understand the page as a Person entity
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Suraj Thapa',
+  url: SITE_URL,
+  jobTitle: 'Software Engineer',
+  description:
+    'Software Engineer with 5+ years of full-stack experience in React, TypeScript, Django, and NestJS.',
+  sameAs: [
+    'https://github.com/SurajFc',
+    'https://www.linkedin.com/in/suraj4/',
+    'https://stackoverflow.com/users/12359814/surajfc',
+  ],
+  knowsAbout: [
+    'JavaScript', 'TypeScript', 'React', 'React Native',
+    'Django', 'NestJS', 'Node.js', 'GraphQL',
+    'PostgreSQL', 'MongoDB', 'AWS',
+  ],
+  email: 'mailto:surajthapafc@gmail.com',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="scroll-smooth" suppressHydrationWarning>
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
       <body className={`${inter.className} overflow-x-hidden`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
           <ScrollProgress />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import Education from '@/components/Education'
 import Projects from '@/components/Projects'
 import Skills from '@/components/Skills'
 import Certifications from '@/components/Certifications'
+import GitHubActivity from '@/components/GitHubActivity'
 import Contact from '@/components/Contact'
 import Footer from '@/components/Footer'
 
@@ -20,6 +21,7 @@ export default function Home() {
       <Projects />
       <Skills />
       <Certifications />
+      <GitHubActivity />
       <Contact />
       <Footer />
     </main>

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,16 +1,57 @@
 'use client'
 
-import { useRef } from 'react'
+import { useRef, useEffect, useState } from 'react'
 import { motion, useInView } from 'framer-motion'
+import Image from 'next/image'
 import SectionHeading from './SectionHeading'
 import DownloadResumeButton from './DownloadResumeButton'
+import { imgSrc } from '@/lib/imgSrc'
 
 const stats = [
-  { label: 'Years Experience', value: '4+' },
-  { label: 'Projects Delivered', value: '10+' },
-  { label: 'Technologies', value: '20+' },
-  { label: 'Companies', value: '3' },
+  { label: 'Years Experience', value: '5+', numeric: 5 },
+  { label: 'Projects Delivered', value: '10+', numeric: 10 },
+  { label: 'Technologies', value: '20+', numeric: 20 },
+  { label: 'Companies', value: '3', numeric: 3 },
 ]
+
+function AnimatedCounter({ numeric, suffix, label }: { numeric: number; suffix: string; label: string }) {
+  const ref = useRef(null)
+  const isInView = useInView(ref, { once: true })
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    if (!isInView) return
+    let start: number | null = null
+    const duration = 1200
+
+    const step = (ts: number) => {
+      if (!start) start = ts
+      const progress = Math.min((ts - start) / duration, 1)
+      // ease-out cubic
+      const eased = 1 - Math.pow(1 - progress, 3)
+      setCount(Math.floor(eased * numeric))
+      if (progress < 1) requestAnimationFrame(step)
+      else setCount(numeric)
+    }
+
+    requestAnimationFrame(step)
+  }, [isInView, numeric])
+
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={isInView ? { opacity: 1, scale: 1 } : {}}
+      transition={{ duration: 0.4 }}
+      className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 transition-all duration-300"
+    >
+      <p className="text-4xl font-bold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
+        {count}{suffix}
+      </p>
+      <p className="text-slate-500 text-sm mt-1">{label}</p>
+    </motion.div>
+  )
+}
 
 export default function About() {
   const ref = useRef(null)
@@ -28,7 +69,8 @@ export default function About() {
           <SectionHeading number="01" title="About Me" />
         </motion.div>
 
-        <div className="grid md:grid-cols-2 gap-12 items-center">
+        <div className="grid md:grid-cols-2 gap-12 items-center mb-12">
+          {/* Bio */}
           <motion.div
             initial={{ opacity: 0, x: -40 }}
             animate={isInView ? { opacity: 1, x: 0 } : {}}
@@ -36,7 +78,7 @@ export default function About() {
           >
             <p className="text-slate-600 dark:text-slate-400 leading-relaxed text-lg">
               I am a versatile software engineer with{' '}
-              <span className="text-indigo-500 dark:text-indigo-400 font-medium">4+ years</span> of industry experience,
+              <span className="text-indigo-500 dark:text-indigo-400 font-medium">5+ years</span> of industry experience,
               having successfully delivered complex technical projects utilizing a variety of
               technologies across{' '}
               <span className="text-indigo-500 dark:text-indigo-400 font-medium">front-end</span> and{' '}
@@ -54,27 +96,48 @@ export default function About() {
             </div>
           </motion.div>
 
+          {/* Profile photo */}
           <motion.div
             initial={{ opacity: 0, x: 40 }}
             animate={isInView ? { opacity: 1, x: 0 } : {}}
             transition={{ duration: 0.6, delay: 0.3 }}
-            className="grid grid-cols-2 gap-4"
+            className="flex justify-center"
           >
-            {stats.map((stat, i) => (
+            <div className="relative w-64 h-64 md:w-72 md:h-72">
+              {/* Glow ring */}
+              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-indigo-500/30 to-purple-500/30 blur-xl scale-105" />
+              <div className="relative w-full h-full rounded-2xl overflow-hidden border-2 border-indigo-500/30">
+                <Image
+                  src={imgSrc('/images/profile.png')}
+                  alt="Suraj Thapa"
+                  fill
+                  className="object-cover object-top"
+                  unoptimized
+                />
+              </div>
+              {/* Floating badge */}
+              <div className="absolute -bottom-4 -right-4 px-4 py-2 rounded-xl bg-indigo-600 text-white text-sm font-semibold shadow-lg shadow-indigo-500/30">
+                5+ yrs exp
+              </div>
+            </div>
+          </motion.div>
+        </div>
+
+        {/* Animated stat counters */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {stats.map((stat, i) => {
+            const suffix = stat.value.replace(/[0-9]/g, '')
+            return (
               <motion.div
                 key={stat.label}
-                initial={{ opacity: 0, scale: 0.9 }}
-                animate={isInView ? { opacity: 1, scale: 1 } : {}}
-                transition={{ duration: 0.4, delay: 0.4 + i * 0.08 }}
-                className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 transition-all duration-300"
+                initial={{ opacity: 0, y: 20 }}
+                animate={isInView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.4, delay: 0.5 + i * 0.08 }}
               >
-                <p className="text-4xl font-bold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
-                  {stat.value}
-                </p>
-                <p className="text-slate-500 text-sm mt-1">{stat.label}</p>
+                <AnimatedCounter numeric={stat.numeric} suffix={suffix} label={stat.label} />
               </motion.div>
-            ))}
-          </motion.div>
+            )
+          })}
         </div>
       </div>
     </section>

--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { HiArrowUp } from 'react-icons/hi'
+
+export default function BackToTop() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 400)
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.button
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 16 }}
+          transition={{ duration: 0.2 }}
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          aria-label="Back to top"
+          className="fixed bottom-8 right-6 z-50 p-3 rounded-full bg-indigo-600 hover:bg-indigo-500 text-white shadow-lg shadow-indigo-500/30 hover:shadow-indigo-500/50 hover:-translate-y-1 transition-all duration-200"
+        >
+          <HiArrowUp className="w-5 h-5" />
+        </motion.button>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -42,7 +42,7 @@ export default function Contact() {
           transition={{ duration: 0.6 }}
           className="mb-4"
         >
-          <SectionHeading number="07" title="Get In Touch" />
+          <SectionHeading number="08" title="Get In Touch" />
         </motion.div>
 
         <motion.p

--- a/components/CursorSpotlight.tsx
+++ b/components/CursorSpotlight.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+export default function CursorSpotlight() {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    // Only on non-touch devices
+    if (window.matchMedia('(hover: none)').matches) return
+
+    const el = ref.current
+    if (!el) return
+
+    const onMove = (e: MouseEvent) => {
+      el.style.transform = `translate(${e.clientX - 200}px, ${e.clientY - 200}px)`
+    }
+
+    window.addEventListener('mousemove', onMove, { passive: true })
+    return () => window.removeEventListener('mousemove', onMove)
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden
+      className="pointer-events-none fixed top-0 left-0 z-0 w-[400px] h-[400px] rounded-full opacity-0 md:opacity-100 transition-opacity duration-500"
+      style={{
+        background: 'radial-gradient(circle, rgba(99,102,241,0.07) 0%, transparent 70%)',
+      }}
+    />
+  )
+}

--- a/components/GitHubActivity.tsx
+++ b/components/GitHubActivity.tsx
@@ -1,0 +1,120 @@
+import SectionHeading from './SectionHeading'
+import { FaGithub, FaStar, FaCodeBranch } from 'react-icons/fa'
+
+interface Repo {
+  id: number
+  name: string
+  description: string | null
+  html_url: string
+  stargazers_count: number
+  forks_count: number
+  language: string | null
+  updated_at: string
+}
+
+const LANG_COLORS: Record<string, string> = {
+  TypeScript: 'bg-blue-400',
+  JavaScript: 'bg-yellow-400',
+  Python: 'bg-green-400',
+  CSS: 'bg-pink-400',
+  HTML: 'bg-orange-400',
+  Vue: 'bg-emerald-400',
+}
+
+async function fetchRepos(): Promise<Repo[]> {
+  try {
+    const res = await fetch(
+      'https://api.github.com/users/SurajFc/repos?sort=updated&per_page=6&type=owner',
+      {
+        headers: { Accept: 'application/vnd.github+json' },
+        // Static export — fetch once at build time
+        cache: 'force-cache',
+      }
+    )
+    if (!res.ok) return []
+    return res.json()
+  } catch {
+    return []
+  }
+}
+
+function timeAgo(dateStr: string) {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const days = Math.floor(diff / 86400000)
+  if (days === 0) return 'today'
+  if (days === 1) return 'yesterday'
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months}mo ago`
+  return `${Math.floor(months / 12)}y ago`
+}
+
+export default async function GitHubActivity() {
+  const repos = await fetchRepos()
+  if (repos.length === 0) return null
+
+  return (
+    <section className="py-24 px-4 bg-black/[0.02] dark:bg-white/[0.02]">
+      <div className="max-w-5xl mx-auto">
+        <div className="mb-12">
+          <SectionHeading number="07" title="GitHub Activity" />
+        </div>
+
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {repos.map((repo) => (
+            <a
+              key={repo.id}
+              href={repo.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex flex-col gap-3 p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 hover:shadow-lg hover:shadow-indigo-500/10 hover:-translate-y-1 transition-all duration-300"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-2 min-w-0">
+                  <FaGithub className="text-slate-500 flex-shrink-0" />
+                  <span className="font-semibold text-slate-900 dark:text-white text-sm truncate group-hover:text-indigo-500 dark:group-hover:text-indigo-400 transition-colors">
+                    {repo.name}
+                  </span>
+                </div>
+              </div>
+
+              <p className="text-slate-500 dark:text-slate-400 text-xs leading-relaxed line-clamp-2 flex-1">
+                {repo.description ?? 'No description'}
+              </p>
+
+              <div className="flex items-center gap-4 text-xs text-slate-500">
+                {repo.language && (
+                  <span className="flex items-center gap-1.5">
+                    <span className={`w-2.5 h-2.5 rounded-full ${LANG_COLORS[repo.language] ?? 'bg-slate-400'}`} />
+                    {repo.language}
+                  </span>
+                )}
+                <span className="flex items-center gap-1">
+                  <FaStar className="text-yellow-500" />
+                  {repo.stargazers_count}
+                </span>
+                <span className="flex items-center gap-1">
+                  <FaCodeBranch />
+                  {repo.forks_count}
+                </span>
+                <span className="ml-auto">{timeAgo(repo.updated_at)}</span>
+              </div>
+            </a>
+          ))}
+        </div>
+
+        <div className="mt-8 text-center">
+          <a
+            href="https://github.com/SurajFc"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-black/10 dark:border-white/10 text-slate-600 dark:text-slate-400 hover:border-indigo-500/40 hover:text-indigo-500 dark:hover:text-indigo-400 transition-all text-sm font-medium"
+          >
+            <FaGithub />
+            View all repositories
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,9 +1,47 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
 import gsap from 'gsap'
 import DownloadResumeButton from './DownloadResumeButton'
+
+const ROLES = [
+  'Software Engineer',
+  'Full Stack Developer',
+  'React Specialist',
+  'Problem Solver',
+]
+
+function Typewriter() {
+  const [roleIdx, setRoleIdx] = useState(0)
+  const [displayed, setDisplayed] = useState('')
+  const [deleting, setDeleting] = useState(false)
+
+  useEffect(() => {
+    const current = ROLES[roleIdx]
+    let timer: ReturnType<typeof setTimeout>
+
+    if (!deleting && displayed.length < current.length) {
+      timer = setTimeout(() => setDisplayed(current.slice(0, displayed.length + 1)), 70)
+    } else if (!deleting && displayed.length === current.length) {
+      timer = setTimeout(() => setDeleting(true), 1800)
+    } else if (deleting && displayed.length > 0) {
+      timer = setTimeout(() => setDisplayed(displayed.slice(0, -1)), 40)
+    } else if (deleting && displayed.length === 0) {
+      setDeleting(false)
+      setRoleIdx((i) => (i + 1) % ROLES.length)
+    }
+
+    return () => clearTimeout(timer)
+  }, [displayed, deleting, roleIdx])
+
+  return (
+    <span>
+      {displayed}
+      <span className="inline-block w-0.5 h-6 md:h-8 bg-indigo-400 ml-0.5 align-middle animate-pulse" />
+    </span>
+  )
+}
 
 export default function Hero() {
   const nameRef = useRef<HTMLHeadingElement>(null)
@@ -74,9 +112,9 @@ export default function Hero() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.9 }}
-          className="text-xl md:text-3xl text-slate-400 mb-10"
+          className="text-xl md:text-3xl text-slate-400 mb-10 h-10 md:h-12 flex items-center justify-center"
         >
-          Software Engineer
+          <Typewriter />
         </motion.p>
 
         <motion.div

--- a/components/ScrollProgress.tsx
+++ b/components/ScrollProgress.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useScroll, useSpring, motion } from 'framer-motion'
+
+export default function ScrollProgress() {
+  const { scrollYProgress } = useScroll()
+  const scaleX = useSpring(scrollYProgress, { stiffness: 100, damping: 30, restDelta: 0.001 })
+
+  return (
+    <motion.div
+      style={{ scaleX }}
+      className="fixed top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-400 z-[60] origin-left"
+    />
+  )
+}

--- a/lib/resume.ts
+++ b/lib/resume.ts
@@ -12,7 +12,7 @@ export const resumeData = {
     stackoverflow: 'stackoverflow.com/users/12359814/surajfc',
   },
   summary:
-    'Versatile software engineer with 4+ years of industry experience, having successfully delivered complex technical projects across front-end and back-end development. A collaborative team member and effective problem solver seeking to contribute to a challenging environment.',
+    'Versatile software engineer with 5+ years of industry experience, having successfully delivered complex technical projects across front-end and back-end development. A collaborative team member and effective problem solver seeking to contribute to a challenging environment.',
   experience: [
     {
       company: 'Mindbrowser Inc',


### PR DESCRIPTION
## Summary

### New features
- **Scroll progress bar** — indigo→purple→pink spring-animated bar at the very top
- **Typewriter effect** — hero subtitle cycles through Software Engineer / Full Stack Developer / React Specialist / Problem Solver with blinking cursor
- **Profile photo in About** — rounded card with glow ring and floating "5+ yrs exp" badge
- **Animated counters** — stat cards count up with ease-out cubic when scrolled into view
- **Cursor spotlight** — subtle indigo radial glow follows mouse (desktop only)
- **Back-to-top button** — appears after 400px scroll, animates in/out
- **GitHub Activity section** — Server Component fetches 6 latest repos at build time (language dot, stars, forks, time-ago)
- **"Thapa" hero gradient** — indigo → purple → pink, distinct from "Suraj"

### SEO
- `keywords`, `authors`, `creator`, `publisher` meta tags
- `robots` with full googleBot directives (index, follow, max previews)
- `alternates.canonical` pointing to the GitHub Pages URL
- Improved Open Graph with `locale`, better alt text
- Twitter `creator` handle
- **JSON-LD Person schema** — `sameAs` social links, `knowsAbout` skills, `jobTitle` — helps Google display rich results

### Other
- 4+ → 5+ across About section, PDF resume summary, and floating badge
- Contact form now submits inline via fetch (no redirect to Formspree page)
- Mobile nav fixed with programmatic `scrollIntoView`
- Dark/light mode toggle with `next-themes`

## Test plan
- [ ] Scroll — progress bar tracks position, back-to-top appears after scrolling down
- [ ] Hero — typewriter cycles through all 4 roles, "Thapa" is purple-pink
- [ ] About — profile photo renders, counters animate on scroll, badge shows "5+ yrs exp"
- [ ] GitHub Activity section shows repos with correct metadata
- [ ] View page source — confirm `<script type="application/ld+json">` is present
- [ ] Paste URL into LinkedIn/Twitter debug tool — confirm OG card renders correctly

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_