### PR TITLE
Wow-factor features: interactive terminal, 3D tilt cards, particle background

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import ScrollProgress from '@/components/ScrollProgress'
 import BackToTop from '@/components/BackToTop'
 import CursorSpotlight from '@/components/CursorSpotlight'
 import PageLoader from '@/components/PageLoader'
+import ParticleBackground from '@/components/ParticleBackground'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -130,6 +131,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className={`${inter.className} overflow-x-hidden`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+          <ParticleBackground />
           <PageLoader />
           <ScrollProgress />
           <CursorSpotlight />

--- a/components/GitHubActivity.tsx
+++ b/components/GitHubActivity.tsx
@@ -112,45 +112,8 @@ export default async function GitHubActivity() {
           ))}
         </div>
 
-        {/* Stats cards */}
-        <div className="mt-10 grid sm:grid-cols-2 gap-4">
-          <div className="p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 overflow-hidden flex items-center justify-center">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="https://github-readme-stats.vercel.app/api?username=SurajFc&show_icons=true&hide_border=true&bg_color=00000000&title_color=6366f1&icon_color=6366f1&text_color=94a3b8&rank_icon=github"
-              alt="GitHub stats for SurajFc"
-              className="w-full"
-            />
-          </div>
-          <div className="p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 overflow-hidden flex items-center justify-center">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="https://github-readme-stats.vercel.app/api/top-langs/?username=SurajFc&layout=compact&hide_border=true&bg_color=00000000&title_color=6366f1&text_color=94a3b8&langs_count=8"
-              alt="Top languages for SurajFc"
-              className="w-full"
-            />
-          </div>
-        </div>
-
-        {/* Trophies */}
-        <div className="mt-10 p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 overflow-hidden">
-          <p className="text-xs text-slate-500 dark:text-slate-400 mb-4 font-medium">Achievements</p>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="https://github-profile-trophy.vercel.app/?username=SurajFc&theme=onedark&no-bg=true&no-frame=true&row=1&column=6&margin-w=8"
-            alt="GitHub trophies for SurajFc"
-            className="w-full hidden dark:block"
-          />
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="https://github-profile-trophy.vercel.app/?username=SurajFc&theme=flat&no-bg=true&no-frame=true&row=1&column=6&margin-w=8"
-            alt="GitHub trophies for SurajFc"
-            className="w-full dark:hidden"
-          />
-        </div>
-
         {/* Contribution graph */}
-        <div className="mt-4 p-4 rounded-xl bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 overflow-hidden">
+        <div className="mt-10 p-4 rounded-xl bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 overflow-hidden">
           <p className="text-xs text-slate-500 dark:text-slate-400 mb-3 font-medium">Contribution Activity</p>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
 import gsap from 'gsap'
 import DownloadResumeButton from './DownloadResumeButton'
+import Terminal from './Terminal'
 
 const ROLES = [
   'Software Engineer',
@@ -142,6 +143,8 @@ export default function Hero() {
             View Projects
           </a>
         </motion.div>
+
+        <Terminal />
       </div>
 
       {/* Scroll indicator */}

--- a/components/ParticleBackground.tsx
+++ b/components/ParticleBackground.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+interface Particle {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  radius: number
+}
+
+export default function ParticleBackground() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    if (window.matchMedia('(hover: none)').matches) return
+
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    let animId: number
+    let mouse = { x: -999, y: -999 }
+    const PARTICLE_COUNT = 70
+    const MAX_DIST = 130
+    const particles: Particle[] = []
+
+    const resize = () => {
+      canvas.width = window.innerWidth
+      canvas.height = window.innerHeight
+    }
+    resize()
+    window.addEventListener('resize', resize)
+
+    const onMouseMove = (e: MouseEvent) => {
+      mouse = { x: e.clientX, y: e.clientY }
+    }
+    window.addEventListener('mousemove', onMouseMove)
+
+    // Seed particles
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      particles.push({
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        vx: (Math.random() - 0.5) * 0.4,
+        vy: (Math.random() - 0.5) * 0.4,
+        radius: Math.random() * 1.5 + 0.5,
+      })
+    }
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      // Move
+      for (const p of particles) {
+        p.x += p.vx
+        p.y += p.vy
+        if (p.x < 0 || p.x > canvas.width) p.vx *= -1
+        if (p.y < 0 || p.y > canvas.height) p.vy *= -1
+      }
+
+      // Draw connections
+      for (let i = 0; i < particles.length; i++) {
+        for (let j = i + 1; j < particles.length; j++) {
+          const dx = particles[i].x - particles[j].x
+          const dy = particles[i].y - particles[j].y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          if (dist < MAX_DIST) {
+            const alpha = (1 - dist / MAX_DIST) * 0.25
+            ctx.beginPath()
+            ctx.moveTo(particles[i].x, particles[i].y)
+            ctx.lineTo(particles[j].x, particles[j].y)
+            ctx.strokeStyle = `rgba(99,102,241,${alpha})`
+            ctx.lineWidth = 0.8
+            ctx.stroke()
+          }
+        }
+
+        // Mouse connections
+        const dx = particles[i].x - mouse.x
+        const dy = particles[i].y - mouse.y
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        if (dist < 160) {
+          const alpha = (1 - dist / 160) * 0.5
+          ctx.beginPath()
+          ctx.moveTo(particles[i].x, particles[i].y)
+          ctx.lineTo(mouse.x, mouse.y)
+          ctx.strokeStyle = `rgba(139,92,246,${alpha})`
+          ctx.lineWidth = 0.8
+          ctx.stroke()
+        }
+      }
+
+      // Draw dots
+      for (const p of particles) {
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2)
+        ctx.fillStyle = 'rgba(99,102,241,0.5)'
+        ctx.fill()
+      }
+
+      animId = requestAnimationFrame(draw)
+    }
+
+    draw()
+
+    return () => {
+      cancelAnimationFrame(animId)
+      window.removeEventListener('resize', resize)
+      window.removeEventListener('mousemove', onMouseMove)
+    }
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="fixed inset-0 pointer-events-none z-0"
+      aria-hidden
+    />
+  )
+}

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRef } from 'react'
-import { motion, useInView } from 'framer-motion'
+import { motion, useInView, useMotionValue, useSpring, useTransform } from 'framer-motion'
 import Image from 'next/image'
 import SectionHeading from './SectionHeading'
 import { imgSrc } from '@/lib/imgSrc'
@@ -57,14 +57,28 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-80px' })
 
+  const mouseX = useMotionValue(0)
+  const mouseY = useMotionValue(0)
+  const rotateX = useSpring(useTransform(mouseY, [-0.5, 0.5], [7, -7]), { stiffness: 300, damping: 30 })
+  const rotateY = useSpring(useTransform(mouseX, [-0.5, 0.5], [-7, 7]), { stiffness: 300, damping: 30 })
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect()
+    mouseX.set((e.clientX - rect.left) / rect.width - 0.5)
+    mouseY.set((e.clientY - rect.top) / rect.height - 0.5)
+  }
+  const handleMouseLeave = () => { mouseX.set(0); mouseY.set(0) }
+
   return (
     <motion.div
       ref={ref}
       initial={{ opacity: 0, y: 40 }}
       animate={isInView ? { opacity: 1, y: 0 } : {}}
       transition={{ duration: 0.5, delay: (index % 2) * 0.15 }}
-      whileHover={{ y: -6 }}
-      className={`group rounded-2xl overflow-hidden bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 ${project.border} transition-all duration-300 shadow-xl ${project.glow}`}
+      style={{ rotateX, rotateY, transformStyle: 'preserve-3d', transformPerspective: 1000 }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      className={`group rounded-2xl overflow-hidden bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 ${project.border} transition-colors duration-300 shadow-xl ${project.glow}`}
     >
       <div className="relative h-52 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent z-10 group-hover:opacity-60 transition-opacity duration-300" />

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useState, useEffect, useRef, KeyboardEvent } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+
+type Line = { type: 'input' | 'output' | 'error'; text: string }
+
+const RESPONSES: Record<string, string[]> = {
+  whoami: [
+    '  Suraj Thapa — Software Engineer',
+    '  5+ years building full-stack web & mobile applications.',
+    '  Currently @ Mindbrowser Inc (Remote).',
+    '  Based in India · Open to global opportunities.',
+  ],
+  skills: [
+    '  Frontend   → React, TypeScript, Next.js, Vue.js, Tailwind',
+    '  Backend    → Django, DRF, NestJS, Node.js, GraphQL',
+    '  Mobile     → React Native, Flutter, Dart',
+    '  AI & ML    → LLM Integration, NLP, OpenAI API, FHIR R4',
+    '  Databases  → PostgreSQL, MongoDB, Redis, Elasticsearch',
+    '  DevOps     → AWS, Docker, Firebase, Git, Turborepo',
+  ],
+  projects: [
+    '  1. WellPro       AI health records platform   (ReactJS, LLM, NLP)',
+    '  2. PeriopMD      Medical subscription portal  (Stripe, MaterialUI)',
+    '  3. TTA Connect   Training marketplace          (Twilio, MSAL, JWT)',
+    '  4. RippleGo      River navigation tracker      (GraphQL, Redux)',
+  ],
+  experience: [
+    '  Mindbrowser Inc   · Software Engineer    Apr 2021 – Present',
+    '  Macco Robotics    · Vue.js Intern         Jul 2020 – Oct 2020',
+    '  Agile Computers   · Python Trainee        Jan 2019 – Jun 2019',
+  ],
+  education: [
+    '  MCA · Bhai Parmanand Institute of Business Studies  (2017–2019)',
+    '  BCA · Vivekananda Institute of Professional Studies (2014–2017)',
+  ],
+  contact: [
+    '  Email     → surajthapafc@gmail.com',
+    '  LinkedIn  → linkedin.com/in/suraj4',
+    '  GitHub    → github.com/SurajFc',
+    '  Schedule  → calendly.com/surajthapafc',
+  ],
+  resume: [
+    '  Preparing your download...',
+    '  CV will download in a moment.',
+  ],
+  help: [
+    '  Available commands:',
+    '  whoami      Who is Suraj?',
+    '  skills      Tech stack overview',
+    '  projects    Featured projects',
+    '  experience  Work history',
+    '  education   Academic background',
+    '  contact     Get in touch',
+    '  resume      Download CV',
+    '  clear       Clear terminal',
+  ],
+}
+
+const BOOT_LINES = [
+  'Suraj Portfolio OS v2.0.0',
+  'Type \'help\' to see available commands.',
+  '',
+]
+
+export default function Terminal() {
+  const [lines, setLines] = useState<Line[]>([])
+  const [input, setInput] = useState('')
+  const [history, setHistory] = useState<string[]>([])
+  const [histIdx, setHistIdx] = useState(-1)
+  const [booted, setBooted] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Boot sequence
+  useEffect(() => {
+    let i = 0
+    const tick = () => {
+      if (i < BOOT_LINES.length) {
+        const text = BOOT_LINES[i]
+        setLines((prev) => [...prev, { type: 'output', text }])
+        i++
+        setTimeout(tick, 120)
+      } else {
+        setBooted(true)
+      }
+    }
+    tick()
+  }, [])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [lines])
+
+  const runCommand = async (cmd: string) => {
+    const trimmed = cmd.trim().toLowerCase()
+    setLines((prev) => [...prev, { type: 'input', text: `$ ${cmd}` }])
+    setHistory((h) => [cmd, ...h].slice(0, 50))
+    setHistIdx(-1)
+
+    if (trimmed === 'clear') {
+      setLines([])
+      return
+    }
+    if (trimmed === '') return
+
+    const response = RESPONSES[trimmed]
+    if (response) {
+      if (trimmed === 'resume') {
+        setLines((prev) => [...prev, ...response.map((t) => ({ type: 'output' as const, text: t }))])
+        const { generateResumePdf } = await import('@/lib/generateResumePdf')
+        const blob = await generateResumePdf()
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = 'Suraj_Thapa_CV.pdf'
+        a.click()
+        URL.revokeObjectURL(url)
+      } else {
+        setLines((prev) => [...prev, ...response.map((t) => ({ type: 'output' as const, text: t }))])
+      }
+    } else {
+      setLines((prev) => [
+        ...prev,
+        { type: 'error', text: `  command not found: ${trimmed}. Type 'help' for options.` },
+      ])
+    }
+  }
+
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      runCommand(input)
+      setInput('')
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      const next = Math.min(histIdx + 1, history.length - 1)
+      setHistIdx(next)
+      setInput(history[next] ?? '')
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      const next = Math.max(histIdx - 1, -1)
+      setHistIdx(next)
+      setInput(next === -1 ? '' : history[next])
+    }
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, delay: 1.4 }}
+      className="w-full max-w-2xl mx-auto mt-10"
+      onClick={() => inputRef.current?.focus()}
+    >
+      {/* Title bar */}
+      <div className="flex items-center gap-2 px-4 py-2.5 bg-zinc-800 rounded-t-xl border border-white/10 border-b-0">
+        <span className="w-3 h-3 rounded-full bg-red-500/80" />
+        <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+        <span className="w-3 h-3 rounded-full bg-green-500/80" />
+        <span className="ml-2 text-xs text-zinc-400 font-mono">suraj@portfolio — terminal</span>
+      </div>
+
+      {/* Body */}
+      <div className="bg-zinc-900/95 border border-white/10 border-t-0 rounded-b-xl p-4 h-64 overflow-y-auto font-mono text-sm cursor-text">
+        {lines.map((line, i) => (
+          <div
+            key={i}
+            className={
+              line.type === 'input'
+                ? 'text-indigo-400 mb-0.5'
+                : line.type === 'error'
+                ? 'text-red-400 mb-0.5'
+                : 'text-zinc-300 mb-0.5'
+            }
+          >
+            {line.text || ' '}
+          </div>
+        ))}
+
+        {booted && (
+          <div className="flex items-center gap-1 text-indigo-400">
+            <span>$</span>
+            <input
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKey}
+              className="flex-1 bg-transparent outline-none text-zinc-100 caret-indigo-400 ml-1"
+              autoComplete="off"
+              spellCheck={false}
+              aria-label="Terminal input"
+            />
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+    </motion.div>
+  )
+}


### PR DESCRIPTION
## Summary

Three standout features that make the portfolio memorable:

### Interactive Terminal
- Fake terminal in the hero section with a boot sequence on load
- Commands: `whoami`, `skills`, `projects`, `experience`, `education`, `contact`, `resume`, `clear`, `help`
- `resume` actually triggers the PDF download
- Arrow up/down cycles through command history (like a real terminal)
- Styled like a macOS terminal with red/yellow/green dots in the title bar

### 3D Tilt Cards
- Project cards tilt toward the cursor on hover using Framer Motion `useMotionValue` + spring physics
- Snaps back smoothly when cursor leaves
- Replaces the previous flat `whileHover: y: -6` effect

### Particle Constellation Background
- 70 indigo particles float across the full page, connecting with lines when nearby
- Moving the cursor draws purple lines to nearby particles
- Automatically disabled on touch devices and for users with `prefers-reduced-motion`

### Also in this branch
- Broken GitHub stats/trophy images removed
- `Open to work` pulsing badge in hero
- Branded ST favicon (32×32 + 180×180 Apple touch icon)
- Custom 404 page, page loader, Calendly button
- GitHub contribution heatmap
- OG image generated at build time
- Expanded skills (6 categories) and certifications

## Test plan

- [ ] Visit hero — terminal boots with welcome message, type `help` to see commands
- [ ] Type `resume` in terminal — PDF downloads
- [ ] Arrow up/down cycles through command history
- [ ] Hover over project cards — 3D tilt effect with spring snap-back
- [ ] Move cursor around — particles connect and draw lines to cursor
- [ ] On mobile — particles disabled, terminal still usable with keyboard
- [ ] Visit a bad URL — custom 404 page shows

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_