### PR TITLE
3D tilt cards across all sections, wow-factor features, and UX fixes

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import SectionHeading from './SectionHeading'
 import DownloadResumeButton from './DownloadResumeButton'
 import { imgSrc } from '@/lib/imgSrc'
+import { useTilt } from '@/lib/useTilt'
 
 const stats = [
   { label: 'Years Experience', value: '5+', numeric: 5 },
@@ -18,6 +19,7 @@ function AnimatedCounter({ numeric, suffix, label }: { numeric: number; suffix: 
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true })
   const [count, setCount] = useState(0)
+  const tilt = useTilt(6)
 
   useEffect(() => {
     if (!isInView) return
@@ -43,7 +45,8 @@ function AnimatedCounter({ numeric, suffix, label }: { numeric: number; suffix: 
       initial={{ opacity: 0, scale: 0.9 }}
       animate={isInView ? { opacity: 1, scale: 1 } : {}}
       transition={{ duration: 0.4 }}
-      className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 transition-all duration-300"
+      {...tilt}
+      className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 transition-colors duration-300"
     >
       <p className="text-4xl font-bold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
         {count}{suffix}

--- a/components/Certifications.tsx
+++ b/components/Certifications.tsx
@@ -3,6 +3,7 @@
 import { useRef } from 'react'
 import { motion, useInView } from 'framer-motion'
 import SectionHeading from './SectionHeading'
+import { useTilt } from '@/lib/useTilt'
 
 const certifications = [
   {
@@ -17,6 +18,27 @@ const certifications = [
   { name: 'Django REST Framework — Building RESTful APIs', issuer: 'Udemy', meta: '', icon: '🔗' },
   { name: 'Node.js: The Complete Guide (NestJS, GraphQL, Deno)', issuer: 'Udemy', meta: '', icon: '🟢' },
 ]
+
+function CertCard({ cert, index, isInView }: { cert: (typeof certifications)[0]; index: number; isInView: boolean }) {
+  const tilt = useTilt(5)
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -30 }}
+      animate={isInView ? { opacity: 1, x: 0 } : {}}
+      transition={{ duration: 0.5, delay: index * 0.1 }}
+      {...tilt}
+      className="flex items-center gap-4 p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/30 transition-colors duration-300"
+    >
+      <span className="text-3xl">{cert.icon}</span>
+      <div>
+        <p className="text-slate-900 dark:text-white font-medium">{cert.name}</p>
+        <p className="text-slate-500 text-sm mt-0.5">
+          {cert.issuer}{cert.meta && ` · ${cert.meta}`}
+        </p>
+      </div>
+    </motion.div>
+  )
+}
 
 export default function Certifications() {
   const ref = useRef(null)
@@ -36,21 +58,7 @@ export default function Certifications() {
 
         <div className="space-y-4">
           {certifications.map((cert, i) => (
-            <motion.div
-              key={cert.name}
-              initial={{ opacity: 0, x: -30 }}
-              animate={isInView ? { opacity: 1, x: 0 } : {}}
-              transition={{ duration: 0.5, delay: i * 0.1 }}
-              className="flex items-center gap-4 p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/30 transition-all duration-300"
-            >
-              <span className="text-3xl">{cert.icon}</span>
-              <div>
-                <p className="text-slate-900 dark:text-white font-medium">{cert.name}</p>
-                <p className="text-slate-500 text-sm mt-0.5">
-                  {cert.issuer}{cert.meta && ` · ${cert.meta}`}
-                </p>
-              </div>
-            </motion.div>
+            <CertCard key={cert.name} cert={cert} index={i} isInView={isInView} />
           ))}
         </div>
       </div>

--- a/components/Education.tsx
+++ b/components/Education.tsx
@@ -3,6 +3,7 @@
 import { useRef } from 'react'
 import { motion, useInView } from 'framer-motion'
 import SectionHeading from './SectionHeading'
+import { useTilt } from '@/lib/useTilt'
 
 const education = [
   {
@@ -16,6 +17,30 @@ const education = [
     date: 'Aug 2014 – July 2017',
   },
 ]
+
+function EducationCard({ edu, index, isInView }: { edu: (typeof education)[0]; index: number; isInView: boolean }) {
+  const tilt = useTilt(6)
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={isInView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.5, delay: index * 0.15 }}
+      {...tilt}
+      className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/30 transition-colors duration-300 group"
+    >
+      <div className="flex items-start gap-4">
+        <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-indigo-500/20 to-purple-500/20 border border-indigo-500/30 flex items-center justify-center text-2xl flex-shrink-0 group-hover:scale-110 transition-transform duration-300">
+          🎓
+        </div>
+        <div>
+          <h3 className="text-slate-900 dark:text-white font-semibold leading-snug">{edu.school}</h3>
+          <p className="text-indigo-500 dark:text-indigo-400 text-sm font-medium mt-1.5">{edu.degree}</p>
+          <p className="text-slate-500 text-xs font-mono mt-2">{edu.date}</p>
+        </div>
+      </div>
+    </motion.div>
+  )
+}
 
 export default function Education() {
   const ref = useRef(null)
@@ -35,24 +60,7 @@ export default function Education() {
 
         <div className="grid md:grid-cols-2 gap-6">
           {education.map((edu, i) => (
-            <motion.div
-              key={edu.school}
-              initial={{ opacity: 0, y: 30 }}
-              animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.5, delay: i * 0.15 }}
-              className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/30 transition-all duration-300 group"
-            >
-              <div className="flex items-start gap-4">
-                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-indigo-500/20 to-purple-500/20 border border-indigo-500/30 flex items-center justify-center text-2xl flex-shrink-0 group-hover:scale-110 transition-transform duration-300">
-                  🎓
-                </div>
-                <div>
-                  <h3 className="text-slate-900 dark:text-white font-semibold leading-snug">{edu.school}</h3>
-                  <p className="text-indigo-500 dark:text-indigo-400 text-sm font-medium mt-1.5">{edu.degree}</p>
-                  <p className="text-slate-500 text-xs font-mono mt-2">{edu.date}</p>
-                </div>
-              </div>
-            </motion.div>
+            <EducationCard key={edu.school} edu={edu} index={i} isInView={isInView} />
           ))}
         </div>
       </div>

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -3,6 +3,7 @@
 import { useRef } from 'react'
 import { motion, useInView } from 'framer-motion'
 import SectionHeading from './SectionHeading'
+import { useTilt } from '@/lib/useTilt'
 
 const experiences = [
   {
@@ -43,6 +44,7 @@ const experiences = [
 function ExperienceItem({ exp, index }: { exp: (typeof experiences)[0]; index: number }) {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-80px' })
+  const tilt = useTilt(5)
 
   return (
     <motion.div
@@ -55,7 +57,7 @@ function ExperienceItem({ exp, index }: { exp: (typeof experiences)[0]; index: n
       <div className="absolute left-0 top-3 bottom-0 w-px bg-gradient-to-b from-black/10 dark:from-white/10 to-transparent" />
       <div className={`absolute left-0 top-2.5 -translate-x-[5px] w-2.5 h-2.5 rounded-full ${exp.dot} shadow-lg`} />
 
-      <div className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 transition-all duration-300">
+      <motion.div {...tilt} className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 transition-colors duration-300">
         <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
           <div>
             <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{exp.company}</h3>
@@ -75,7 +77,7 @@ function ExperienceItem({ exp, index }: { exp: (typeof experiences)[0]; index: n
             </li>
           ))}
         </ul>
-      </div>
+      </motion.div>
     </motion.div>
   )
 }

--- a/components/GitHubActivity.tsx
+++ b/components/GitHubActivity.tsx
@@ -1,5 +1,6 @@
 import SectionHeading from './SectionHeading'
-import { FaGithub, FaStar, FaCodeBranch } from 'react-icons/fa'
+import RepoCards from './RepoCards'
+import { FaGithub } from 'react-icons/fa'
 
 interface Repo {
   id: number
@@ -10,15 +11,6 @@ interface Repo {
   forks_count: number
   language: string | null
   updated_at: string
-}
-
-const LANG_COLORS: Record<string, string> = {
-  TypeScript: 'bg-blue-400',
-  JavaScript: 'bg-yellow-400',
-  Python: 'bg-green-400',
-  CSS: 'bg-pink-400',
-  HTML: 'bg-orange-400',
-  Vue: 'bg-emerald-400',
 }
 
 // Update this list to match your pinned repos on github.com/SurajFc
@@ -47,16 +39,6 @@ async function fetchRepos(): Promise<Repo[]> {
   }
 }
 
-function timeAgo(dateStr: string) {
-  const diff = Date.now() - new Date(dateStr).getTime()
-  const days = Math.floor(diff / 86400000)
-  if (days === 0) return 'today'
-  if (days === 1) return 'yesterday'
-  if (days < 30) return `${days}d ago`
-  const months = Math.floor(days / 30)
-  if (months < 12) return `${months}mo ago`
-  return `${Math.floor(months / 12)}y ago`
-}
 
 export default async function GitHubActivity() {
   const repos = await fetchRepos()
@@ -69,48 +51,7 @@ export default async function GitHubActivity() {
           <SectionHeading number="07" title="GitHub Activity" />
         </div>
 
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {repos.map((repo) => (
-            <a
-              key={repo.id}
-              href={repo.html_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group flex flex-col gap-3 p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 hover:shadow-lg hover:shadow-indigo-500/10 hover:-translate-y-1 transition-all duration-300"
-            >
-              <div className="flex items-start justify-between gap-2">
-                <div className="flex items-center gap-2 min-w-0">
-                  <FaGithub className="text-slate-500 flex-shrink-0" />
-                  <span className="font-semibold text-slate-900 dark:text-white text-sm truncate group-hover:text-indigo-500 dark:group-hover:text-indigo-400 transition-colors">
-                    {repo.name}
-                  </span>
-                </div>
-              </div>
-
-              <p className="text-slate-500 dark:text-slate-400 text-xs leading-relaxed line-clamp-2 flex-1">
-                {repo.description ?? 'No description'}
-              </p>
-
-              <div className="flex items-center gap-4 text-xs text-slate-500">
-                {repo.language && (
-                  <span className="flex items-center gap-1.5">
-                    <span className={`w-2.5 h-2.5 rounded-full ${LANG_COLORS[repo.language] ?? 'bg-slate-400'}`} />
-                    {repo.language}
-                  </span>
-                )}
-                <span className="flex items-center gap-1">
-                  <FaStar className="text-yellow-500" />
-                  {repo.stargazers_count}
-                </span>
-                <span className="flex items-center gap-1">
-                  <FaCodeBranch />
-                  {repo.forks_count}
-                </span>
-                <span className="ml-auto">{timeAgo(repo.updated_at)}</span>
-              </div>
-            </a>
-          ))}
-        </div>
+        <RepoCards repos={repos} />
 
         {/* Contribution graph */}
         <div className="mt-10 p-4 rounded-xl bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 overflow-hidden">

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -60,7 +60,7 @@ export default function Hero() {
   return (
     <section
       id="home"
-      className="relative min-h-screen flex items-center justify-center overflow-hidden"
+      className="relative min-h-screen flex flex-col justify-center overflow-hidden"
     >
       {/* Gradient orbs */}
       <div className="absolute inset-0 pointer-events-none overflow-hidden">
@@ -75,75 +75,79 @@ export default function Hero() {
       {/* Subtle grid */}
       <div className="absolute inset-0 bg-[linear-gradient(rgba(99,102,241,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(99,102,241,0.03)_1px,transparent_1px)] bg-[size:60px_60px]" />
 
-      <div className="relative z-10 text-center px-4">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.1 }}
-          className="flex items-center justify-center gap-4 mb-5"
-        >
-          <p className="text-indigo-400 font-mono text-base md:text-lg tracking-widest">
-            Hi there, I&apos;m
-          </p>
-          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/30 text-emerald-400 text-xs font-medium">
-            <span className="relative flex h-2 w-2">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-              <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
-            </span>
-            Open to work
-          </span>
-        </motion.div>
-
-        <h1
-          ref={nameRef}
-          aria-label="Suraj Thapa"
-          className="text-6xl md:text-8xl lg:text-9xl font-bold mb-4 overflow-hidden leading-none"
-        >
-          {'Suraj'.split('').map((char, i) => (
-            <span
-              key={`s-${i}`}
-              className="char inline-block bg-gradient-to-b from-white to-slate-400 bg-clip-text text-transparent"
-            >
-              {char}
-            </span>
-          ))}
-          <span className="char inline-block">&nbsp;</span>
-          {'Thapa'.split('').map((char, i) => (
-            <span
-              key={`t-${i}`}
-              className="char inline-block bg-gradient-to-br from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent"
-            >
-              {char}
-            </span>
-          ))}
-        </h1>
-
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.9 }}
-          className="text-xl md:text-3xl text-slate-400 mb-10 h-10 md:h-12 flex items-center justify-center"
-        >
-          <Typewriter />
-        </motion.p>
-
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 1.1 }}
-          className="flex flex-col sm:flex-row gap-4 justify-center"
-        >
-          <DownloadResumeButton className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-70 disabled:cursor-wait text-white rounded-lg font-medium transition-all duration-300 hover:shadow-xl hover:shadow-indigo-500/30 hover:-translate-y-0.5">
-            Download CV
-          </DownloadResumeButton>
-          <a
-            href="#projects"
-            className="px-8 py-3 border border-indigo-500/40 hover:border-indigo-400 text-slate-300 hover:text-white rounded-lg font-medium transition-all duration-300 hover:-translate-y-0.5 hover:bg-indigo-500/10"
+      <div className="relative z-10 w-full flex flex-col items-center px-4 py-24">
+        {/* Centered hero content */}
+        <div className="text-center">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.1 }}
+            className="flex items-center justify-center gap-4 mb-5"
           >
-            View Projects
-          </a>
-        </motion.div>
+            <p className="text-indigo-400 font-mono text-base md:text-lg tracking-widest">
+              Hi there, I&apos;m
+            </p>
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/30 text-emerald-400 text-xs font-medium">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+              </span>
+              Open to work
+            </span>
+          </motion.div>
 
+          <h1
+            ref={nameRef}
+            aria-label="Suraj Thapa"
+            className="text-6xl md:text-8xl lg:text-9xl font-bold mb-4 overflow-hidden leading-none"
+          >
+            {'Suraj'.split('').map((char, i) => (
+              <span
+                key={`s-${i}`}
+                className="char inline-block bg-gradient-to-b from-white to-slate-400 bg-clip-text text-transparent"
+              >
+                {char}
+              </span>
+            ))}
+            <span className="char inline-block">&nbsp;</span>
+            {'Thapa'.split('').map((char, i) => (
+              <span
+                key={`t-${i}`}
+                className="char inline-block bg-gradient-to-br from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent"
+              >
+                {char}
+              </span>
+            ))}
+          </h1>
+
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.9 }}
+            className="text-xl md:text-3xl text-slate-400 mb-10 h-10 md:h-12 flex items-center justify-center"
+          >
+            <Typewriter />
+          </motion.p>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 1.1 }}
+            className="flex flex-col sm:flex-row gap-4 justify-center"
+          >
+            <DownloadResumeButton className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-70 disabled:cursor-wait text-white rounded-lg font-medium transition-all duration-300 hover:shadow-xl hover:shadow-indigo-500/30 hover:-translate-y-0.5">
+              Download CV
+            </DownloadResumeButton>
+            <a
+              href="#projects"
+              className="px-8 py-3 border border-indigo-500/40 hover:border-indigo-400 text-slate-300 hover:text-white rounded-lg font-medium transition-all duration-300 hover:-translate-y-0.5 hover:bg-indigo-500/10"
+            >
+              View Projects
+            </a>
+          </motion.div>
+        </div>
+
+        {/* Terminal sits below the centered content, not affecting vertical centering */}
         <Terminal />
       </div>
 

--- a/components/RepoCards.tsx
+++ b/components/RepoCards.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { FaGithub, FaStar, FaCodeBranch } from 'react-icons/fa'
+import { useTilt } from '@/lib/useTilt'
+
+interface Repo {
+  id: number
+  name: string
+  description: string | null
+  html_url: string
+  stargazers_count: number
+  forks_count: number
+  language: string | null
+  updated_at: string
+}
+
+const LANG_COLORS: Record<string, string> = {
+  TypeScript: 'bg-blue-400',
+  JavaScript: 'bg-yellow-400',
+  Python: 'bg-green-400',
+  CSS: 'bg-pink-400',
+  HTML: 'bg-orange-400',
+  Vue: 'bg-emerald-400',
+  Dart: 'bg-cyan-400',
+}
+
+function timeAgo(dateStr: string) {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const days = Math.floor(diff / 86400000)
+  if (days === 0) return 'today'
+  if (days === 1) return 'yesterday'
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months}mo ago`
+  return `${Math.floor(months / 12)}y ago`
+}
+
+function RepoCard({ repo, index }: { repo: Repo; index: number }) {
+  const tilt = useTilt(6)
+  return (
+    <motion.a
+      key={repo.id}
+      href={repo.html_url}
+      target="_blank"
+      rel="noopener noreferrer"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: index * 0.07 }}
+      {...tilt}
+      className="group flex flex-col gap-3 p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 hover:shadow-lg hover:shadow-indigo-500/10 transition-colors duration-300"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <FaGithub className="text-slate-500 flex-shrink-0" />
+          <span className="font-semibold text-slate-900 dark:text-white text-sm truncate group-hover:text-indigo-500 dark:group-hover:text-indigo-400 transition-colors">
+            {repo.name}
+          </span>
+        </div>
+      </div>
+
+      <p className="text-slate-500 dark:text-slate-400 text-xs leading-relaxed line-clamp-2 flex-1">
+        {repo.description ?? 'No description'}
+      </p>
+
+      <div className="flex items-center gap-4 text-xs text-slate-500">
+        {repo.language && (
+          <span className="flex items-center gap-1.5">
+            <span className={`w-2.5 h-2.5 rounded-full ${LANG_COLORS[repo.language] ?? 'bg-slate-400'}`} />
+            {repo.language}
+          </span>
+        )}
+        <span className="flex items-center gap-1">
+          <FaStar className="text-yellow-500" />
+          {repo.stargazers_count}
+        </span>
+        <span className="flex items-center gap-1">
+          <FaCodeBranch />
+          {repo.forks_count}
+        </span>
+        <span className="ml-auto">{timeAgo(repo.updated_at)}</span>
+      </div>
+    </motion.a>
+  )
+}
+
+export default function RepoCards({ repos }: { repos: Repo[] }) {
+  return (
+    <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {repos.map((repo, i) => (
+        <RepoCard key={repo.id} repo={repo} index={i} />
+      ))}
+    </div>
+  )
+}

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -3,6 +3,7 @@
 import { useRef } from 'react'
 import { motion, useInView } from 'framer-motion'
 import SectionHeading from './SectionHeading'
+import { useTilt } from '@/lib/useTilt'
 
 const skillCategories = [
   {
@@ -43,6 +44,37 @@ const skillCategories = [
   },
 ]
 
+function SkillCard({ cat, catIndex, isInView }: { cat: (typeof skillCategories)[0]; catIndex: number; isInView: boolean }) {
+  const tilt = useTilt(6)
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={isInView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.5, delay: catIndex * 0.1 }}
+      {...tilt}
+      className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 transition-colors duration-300"
+    >
+      <div className="flex items-center gap-2 mb-4">
+        <div className={`w-2.5 h-2.5 rounded-full ${cat.dot}`} />
+        <h3 className="text-slate-900 dark:text-white font-semibold">{cat.name}</h3>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {cat.skills.map((skill, i) => (
+          <motion.span
+            key={skill}
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={isInView ? { opacity: 1, scale: 1 } : {}}
+            transition={{ duration: 0.3, delay: catIndex * 0.1 + i * 0.04 }}
+            className={`text-sm px-3 py-1 rounded-full border ${cat.badge}`}
+          >
+            {skill}
+          </motion.span>
+        ))}
+      </div>
+    </motion.div>
+  )
+}
+
 export default function Skills() {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-100px' })
@@ -61,31 +93,7 @@ export default function Skills() {
 
         <div className="grid md:grid-cols-2 gap-6">
           {skillCategories.map((cat, catIndex) => (
-            <motion.div
-              key={cat.name}
-              initial={{ opacity: 0, y: 30 }}
-              animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.5, delay: catIndex * 0.1 }}
-              className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 transition-all duration-300"
-            >
-              <div className="flex items-center gap-2 mb-4">
-                <div className={`w-2.5 h-2.5 rounded-full ${cat.dot}`} />
-                <h3 className="text-slate-900 dark:text-white font-semibold">{cat.name}</h3>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {cat.skills.map((skill, i) => (
-                  <motion.span
-                    key={skill}
-                    initial={{ opacity: 0, scale: 0.8 }}
-                    animate={isInView ? { opacity: 1, scale: 1 } : {}}
-                    transition={{ duration: 0.3, delay: catIndex * 0.1 + i * 0.04 }}
-                    className={`text-sm px-3 py-1 rounded-full border ${cat.badge}`}
-                  >
-                    {skill}
-                  </motion.span>
-                ))}
-              </div>
-            </motion.div>
+            <SkillCard key={cat.name} cat={cat} catIndex={catIndex} isInView={isInView} />
           ))}
         </div>
       </div>

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -150,7 +150,7 @@ export default function Terminal() {
       initial={{ opacity: 0, y: 24 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, delay: 1.4 }}
-      className="w-full max-w-2xl mx-auto mt-10"
+      className="hidden sm:block w-full max-w-2xl mx-auto mt-10"
       onClick={() => inputRef.current?.focus()}
     >
       {/* Title bar */}

--- a/lib/useTilt.ts
+++ b/lib/useTilt.ts
@@ -1,0 +1,26 @@
+import { useMotionValue, useSpring, useTransform } from 'framer-motion'
+import type { MouseEvent } from 'react'
+
+export function useTilt(strength = 7) {
+  const mouseX = useMotionValue(0)
+  const mouseY = useMotionValue(0)
+  const rotateX = useSpring(useTransform(mouseY, [-0.5, 0.5], [strength, -strength]), { stiffness: 300, damping: 30 })
+  const rotateY = useSpring(useTransform(mouseX, [-0.5, 0.5], [-strength, strength]), { stiffness: 300, damping: 30 })
+
+  const onMouseMove = (e: MouseEvent<HTMLElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect()
+    mouseX.set((e.clientX - rect.left) / rect.width - 0.5)
+    mouseY.set((e.clientY - rect.top) / rect.height - 0.5)
+  }
+
+  const onMouseLeave = () => {
+    mouseX.set(0)
+    mouseY.set(0)
+  }
+
+  return {
+    style: { rotateX, rotateY, transformStyle: 'preserve-3d' as const, transformPerspective: 1000 },
+    onMouseMove,
+    onMouseLeave,
+  }
+}


### PR DESCRIPTION
## Summary

### 3D Tilt Cards — Everywhere
- Created reusable `useTilt` hook (`lib/useTilt.ts`) with Framer Motion spring physics
- Applied to all card sections: About (stat counters), Experience, Education, Skills, Certifications, GitHub Activity (repo cards), and Projects
- GitHub Activity cards extracted to `RepoCards.tsx` client component to support hooks

### Wow-Factor Features
- **Interactive Terminal** — hero terminal with boot sequence, commands (`whoami`, `skills`, `projects`, `experience`, `education`, `contact`, `resume`, `clear`), arrow-key history, and actual PDF download on `resume`
- **Particle Constellation** — 70 indigo particles with cursor-reactive connections across the full page; disabled on touch devices and `prefers-reduced-motion`
- **Branded ST Favicon** — indigo/purple/pink gradient, generated at build time (32×32 + 180×180 Apple touch icon)

### UX Fixes
- Hero layout restructured: name/greeting always vertically centered, terminal flows below — fixes "Hi there, I'm" drifting into the navbar on desktop
- Terminal hidden on mobile to prevent scroll indicator overlap

### Other Enhancements
- `Open to work` pulsing green badge in hero
- Calendly "Schedule a Call" + "Send an Email" buttons in Contact
- GitHub contribution heatmap in GitHub Activity
- Pinned repos list in GitHub Activity
- Portfolio URL in PDF resume contact row
- OG image (1200×630) generated at build time
- Expanded skills (6 categories) + 3 new Udemy certifications

## Test plan

- [ ] Hover over cards in every section — 3D tilt with spring snap-back
- [ ] Hero: name/typewriter centered, terminal below, scroll indicator visible
- [ ] Terminal: type `help`, `skills`, `resume` (triggers PDF download)
- [ ] Particles visible on desktop, absent on mobile/touch
- [ ] Favicon shows ST initials in browser tab
- [ ] `Open to work` badge pulses in hero
- [ ] Mobile: terminal hidden, scroll indicator visible

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_