### PR TITLE
Show terminal on mobile with compact layout

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -150,7 +150,7 @@ export default function Terminal() {
       initial={{ opacity: 0, y: 24 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, delay: 1.4 }}
-      className="hidden sm:block w-full max-w-2xl mx-auto mt-10"
+      className="block w-full max-w-2xl mx-auto mt-8 sm:mt-10"
       onClick={() => inputRef.current?.focus()}
     >
       {/* Title bar */}
@@ -162,7 +162,7 @@ export default function Terminal() {
       </div>
 
       {/* Body */}
-      <div className="bg-zinc-900/95 border border-white/10 border-t-0 rounded-b-xl p-4 h-64 overflow-y-auto font-mono text-sm cursor-text">
+      <div className="bg-zinc-900/95 border border-white/10 border-t-0 rounded-b-xl p-3 sm:p-4 h-44 sm:h-64 overflow-y-auto font-mono text-xs sm:text-sm cursor-text">
         {lines.map((line, i) => (
           <div
             key={i}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Terminal was previously hidden on mobile (`hidden sm:block`) to avoid overlapping the scroll indicator
- Now visible on all screen sizes with a compact mobile layout: `h-44` height, `text-xs` font, `p-3` padding
- Desktop (`sm+`) remains unchanged: `h-64`, `text-sm`, `p-4`

## Test plan

- [ ] Open site on mobile — terminal should appear below the hero buttons
- [ ] Scroll indicator (animated line + "scroll" text) should still be visible below the terminal
- [ ] Terminal is interactive on mobile (tap to focus, type commands)
- [ ] Desktop layout unchanged

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_