### PR TITLE
Fix light mode contrast and page load scroll position

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -104,7 +104,7 @@ export default function Hero() {
             {'Suraj'.split('').map((char, i) => (
               <span
                 key={`s-${i}`}
-                className="char inline-block bg-gradient-to-b from-white to-slate-400 bg-clip-text text-transparent"
+                className="char inline-block bg-gradient-to-b from-slate-800 to-slate-500 dark:from-white dark:to-slate-400 bg-clip-text text-transparent"
               >
                 {char}
               </span>
@@ -140,7 +140,7 @@ export default function Hero() {
             </DownloadResumeButton>
             <a
               href="#projects"
-              className="px-8 py-3 border border-indigo-500/40 hover:border-indigo-400 text-slate-300 hover:text-white rounded-lg font-medium transition-all duration-300 hover:-translate-y-0.5 hover:bg-indigo-500/10"
+              className="px-8 py-3 border border-indigo-500/60 dark:border-indigo-500/40 hover:border-indigo-400 text-slate-700 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-white rounded-lg font-medium transition-all duration-300 hover:-translate-y-0.5 hover:bg-indigo-500/10"
             >
               View Projects
             </a>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -48,6 +48,11 @@ export default function Hero() {
   const nameRef = useRef<HTMLHeadingElement>(null)
 
   useEffect(() => {
+    window.history.scrollRestoration = 'manual'
+    window.scrollTo(0, 0)
+  }, [])
+
+  useEffect(() => {
     if (!nameRef.current) return
     const chars = nameRef.current.querySelectorAll('.char')
     gsap.fromTo(


### PR DESCRIPTION
## Summary

- **Light mode contrast**: "Suraj" name was invisible (white gradient on white bg) — switched to dark slate gradient in light mode. "View Projects" button text was near-invisible (`slate-300`) — changed to `slate-700` in light mode
- **Scroll to top on load**: Browser was restoring previous scroll position, making the page appear to jump to "About" on load — disabled scroll restoration and force `scrollTo(0,0)` on mount

## Test plan

- [ ] Switch to light mode — "Suraj" name clearly visible, "View Projects" button text readable
- [ ] Reload page — should always start at the very top (Hero section), not "About"
- [ ] Dark mode unchanged

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_