### PR TITLE
Fix page always scrolling to About on load (mobile & desktop)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,7 +19,7 @@
 }
 
 html {
-  scroll-behavior: smooth;
+  scroll-behavior: auto;
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -122,8 +122,10 @@ const jsonLd = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="scroll-smooth" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Disable browser scroll restoration before any JS runs */}
+        <script dangerouslySetInnerHTML={{ __html: `history.scrollRestoration='manual';` }} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,7 +24,10 @@ export default function Header() {
   useEffect(() => { setMounted(true) }, [])
 
   useEffect(() => {
-    const handleScroll = () => setScrolled(window.scrollY > 50)
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 50)
+      if (window.scrollY < 100) setActiveSection('')
+    }
     window.addEventListener('scroll', handleScroll)
     return () => window.removeEventListener('scroll', handleScroll)
   }, [])


### PR DESCRIPTION
## Summary

- **Inline scroll restoration script**: Added `history.scrollRestoration='manual'` as an inline `<script>` in `<head>` so it runs before React hydrates — prevents browser from ever restoring a previous scroll position
- **Removed `scroll-smooth` from `<html>`**: CSS `scroll-behavior: smooth` was causing the browser to animate the scroll restoration, making it look like the page navigated to "About"
- **Clear active nav section at top**: `IntersectionObserver` was firing on mount and marking "About" as active. Now resets `activeSection` to `''` whenever scroll position is within 100px of the top, so no nav link is highlighted while the hero is in view

## Test plan

- [ ] Reload page on mobile — stays at top (Hero), "About" nav link not highlighted
- [ ] Reload page on desktop — same behaviour
- [ ] Scroll down to About — "About" nav link becomes active correctly
- [ ] Scroll back to top — nav highlight clears

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_