### PR TITLE
Fix reload scroll + show all 6 GitHub repos

### DIFF
--- a/components/GitHubActivity.tsx
+++ b/components/GitHubActivity.tsx
@@ -17,7 +17,7 @@ interface Repo {
 const PINNED_REPOS = [
   'surajPortfolio',
   'smart-on-fhir-app',
-  'balajee-erp',
+  'Django-DRF-Boilerplate-with-otp-verification',
   'react-fhir-forms',
   'NestJsAuth',
   'Django-JWT-boilerplate',

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -48,8 +48,15 @@ export default function Hero() {
   const nameRef = useRef<HTMLHeadingElement>(null)
 
   useEffect(() => {
-    window.history.scrollRestoration = 'manual'
-    window.scrollTo(0, 0)
+    // Strip hash from URL (hash-based scroll ignores scrollRestoration)
+    if (window.location.hash) {
+      history.replaceState(null, document.title, window.location.pathname)
+    }
+    // rAF ensures this runs after any browser scroll restoration attempt
+    const raf = requestAnimationFrame(() => {
+      window.scrollTo(0, 0)
+    })
+    return () => cancelAnimationFrame(raf)
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Scroll to top on reload**: Strips any `#hash` from the URL on mount (hash-based scroll ignores `scrollRestoration`) and uses `requestAnimationFrame` so `scrollTo(0,0)` fires after any browser scroll restoration attempt
- **6th GitHub repo card**: `balajee-erp` is a private repo — the GitHub API returns nothing for it, so it was silently filtered out. Replaced with `Django-DRF-Boilerplate-with-otp-verification` (most-starred public repo: 10 ⭐, 7 forks)

## Test plan

- [ ] Reload page — stays at top, no scroll to About
- [ ] GitHub Activity section shows 6 repo cards
- [ ] Nav About link not highlighted on initial load

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_