### PR TITLE
Fix scroll-to-top root cause + Vercel deployment support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Build static site
         run: npm run build
+        env:
+          GITHUB_PAGES: true
 
       - name: Disable Jekyll processing
         run: touch ./out/.nojekyll

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,13 @@
-const isProd = process.env.NODE_ENV === 'production'
-const repo = 'surajPortfolio' // GitHub Pages project path: /surajPortfolio
-const basePath = isProd ? `/${repo}` : ''
+const isGitHubPages = process.env.GITHUB_PAGES === 'true'
+const repo = 'surajPortfolio'
+const basePath = isGitHubPages ? `/${repo}` : ''
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
   trailingSlash: true,
   basePath,
-  // assetPrefix (no trailing slash) prefixes _next/static JS/CSS chunks
   assetPrefix: basePath,
-  // Expose basePath to client code so components can prefix public/ image paths
   env: { NEXT_PUBLIC_BASE_PATH: basePath },
   images: { unoptimized: true },
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "out",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary

### Scroll fix (root cause found)
The terminal boot sequence was calling `scrollIntoView()` on a sentinel `<div>` to keep the latest boot line visible. `scrollIntoView` bubbles up through all scrollable ancestors including `window` — so on every load, the page scrolled to wherever the terminal sits (near About on mobile). Fixed by switching to `body.scrollTop = body.scrollHeight` which only scrolls the terminal's own container. The 600ms defensive interval in Hero is replaced with a clean single `requestAnimationFrame` reset.

### Vercel deployment
- `next.config.js` previously used `NODE_ENV === 'production'` to set `basePath=/surajPortfolio` — this also fired on Vercel, breaking all routes
- Switched to `GITHUB_PAGES=true` env var (set in the Actions workflow) so Vercel builds get `basePath=''` (served from root)
- Added `vercel.json` pointing at the `out/` static export directory

To deploy on Vercel: import the repo, no extra settings needed. The `out/` directory is served as-is.

## Test plan

- [ ] Page reload stays at top on mobile and desktop
- [ ] GitHub Pages deploy still works (Actions workflow sets `GITHUB_PAGES=true`)
- [ ] Vercel deploy serves site from root (no `/surajPortfolio` prefix)

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_