### PR TITLE
Fix Vercel build: serve static export instead of Next.js builder

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "out",
-  "framework": "nextjs"
+  "framework": null
 }


### PR DESCRIPTION
## Summary

The Vercel build was failing with:
```
Error: The file "/vercel/path0/out/routes-manifest.json" couldn't be found.
```

`vercel.json` had `"framework": "nextjs"`, which made Vercel run its Next.js builder. That builder expects a `.next/routes-manifest.json`, but with `output: 'export'` the project produces a plain static `out/` directory with no manifest — so the build errored after compiling successfully.

Setting `"framework": null` tells Vercel to treat it as a generic static build: run `npm run build` and serve the `out/` directory as-is.

## Test plan

- [ ] Vercel build completes without the routes-manifest error
- [ ] Deployed Vercel site serves the portfolio from root
- [ ] GitHub Pages deploy unaffected

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_