### PR TITLE
6 UI enhancements: magnetic buttons, gradient mesh, grain, counters, project preview, social sidebar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -38,3 +38,22 @@ html:not(.dark) body {
 ::-webkit-scrollbar-thumb { background: #6366f1; border-radius: 10px; }
 
 ::selection { background: #6366f1; color: white; }
+
+@keyframes mesh1 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33%       { transform: translate(80px, -60px) scale(1.1); }
+  66%       { transform: translate(-40px, 80px) scale(0.95); }
+}
+@keyframes mesh2 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33%       { transform: translate(-70px, 50px) scale(1.05); }
+  66%       { transform: translate(60px, -70px) scale(0.9); }
+}
+@keyframes mesh3 {
+  0%, 100% { transform: translate(-50%, -50%) scale(1); }
+  50%       { transform: translate(-50%, -50%) scale(1.25); }
+}
+
+.animate-mesh1 { animation: mesh1 22s ease-in-out infinite; }
+.animate-mesh2 { animation: mesh2 28s ease-in-out infinite; }
+.animate-mesh3 { animation: mesh3 18s ease-in-out infinite; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,9 @@ import BackToTop from '@/components/BackToTop'
 import CursorSpotlight from '@/components/CursorSpotlight'
 import PageLoader from '@/components/PageLoader'
 import ParticleBackground from '@/components/ParticleBackground'
+import GradientMesh from '@/components/GradientMesh'
+import GrainOverlay from '@/components/GrainOverlay'
+import SocialSidebar from '@/components/SocialSidebar'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -134,10 +137,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className={`${inter.className} overflow-x-hidden`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+          <GradientMesh />
+          <GrainOverlay />
           <ParticleBackground />
           <PageLoader />
           <ScrollProgress />
           <CursorSpotlight />
+          <SocialSidebar />
           {children}
           <BackToTop />
           <Analytics />

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -48,10 +48,10 @@ function AnimatedCounter({ numeric, suffix, label }: { numeric: number; suffix: 
       {...tilt}
       className="p-6 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 transition-colors duration-300"
     >
-      <p className="text-4xl font-bold bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
+      <p className="text-5xl font-bold bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent tabular-nums">
         {count}{suffix}
       </p>
-      <p className="text-slate-500 text-sm mt-1">{label}</p>
+      <p className="text-slate-500 dark:text-slate-400 text-sm mt-2 font-medium">{label}</p>
     </motion.div>
   )
 }

--- a/components/GradientMesh.tsx
+++ b/components/GradientMesh.tsx
@@ -1,0 +1,9 @@
+export default function GradientMesh() {
+  return (
+    <div aria-hidden className="fixed inset-0 -z-10 pointer-events-none overflow-hidden">
+      <div className="absolute w-[700px] h-[700px] rounded-full bg-indigo-600/[0.07] dark:bg-indigo-600/[0.12] blur-[100px] animate-mesh1 -top-40 -left-40" />
+      <div className="absolute w-[600px] h-[600px] rounded-full bg-purple-600/[0.07] dark:bg-purple-600/[0.10] blur-[100px] animate-mesh2 -bottom-40 -right-40" />
+      <div className="absolute w-[500px] h-[500px] rounded-full bg-pink-600/[0.05] dark:bg-pink-600/[0.08] blur-[80px] animate-mesh3 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
+    </div>
+  )
+}

--- a/components/GrainOverlay.tsx
+++ b/components/GrainOverlay.tsx
@@ -1,0 +1,16 @@
+export default function GrainOverlay() {
+  return (
+    <div
+      aria-hidden
+      className="fixed inset-0 z-[2] pointer-events-none select-none opacity-[0.022] dark:opacity-[0.038]"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
+        <filter id="grain">
+          <feTurbulence type="fractalNoise" baseFrequency="0.68" numOctaves="4" stitchTiles="stitch" />
+          <feColorMatrix type="saturate" values="0" />
+        </filter>
+        <rect width="100%" height="100%" filter="url(#grain)" />
+      </svg>
+    </div>
+  )
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 import gsap from 'gsap'
 import DownloadResumeButton from './DownloadResumeButton'
 import Terminal from './Terminal'
+import { useMagnetic } from '@/lib/useMagnetic'
 
 const ROLES = [
   'Software Engineer',
@@ -41,6 +42,15 @@ function Typewriter() {
       {displayed}
       <span className="inline-block w-0.5 h-6 md:h-8 bg-indigo-400 ml-0.5 align-middle animate-pulse" />
     </span>
+  )
+}
+
+function MagneticButton({ children }: { children: React.ReactNode }) {
+  const mag = useMagnetic(0.35)
+  return (
+    <motion.div style={mag.style} onMouseMove={mag.onMouseMove} onMouseLeave={mag.onMouseLeave}>
+      {children}
+    </motion.div>
   )
 }
 
@@ -147,15 +157,19 @@ export default function Hero() {
             transition={{ duration: 0.6, delay: 1.1 }}
             className="flex flex-col sm:flex-row gap-4 justify-center"
           >
-            <DownloadResumeButton className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-70 disabled:cursor-wait text-white rounded-lg font-medium transition-all duration-300 hover:shadow-xl hover:shadow-indigo-500/30 hover:-translate-y-0.5">
-              Download CV
-            </DownloadResumeButton>
-            <a
-              href="#projects"
-              className="px-8 py-3 border border-indigo-500/60 dark:border-indigo-500/40 hover:border-indigo-400 text-slate-700 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-white rounded-lg font-medium transition-all duration-300 hover:-translate-y-0.5 hover:bg-indigo-500/10"
-            >
-              View Projects
-            </a>
+            <MagneticButton>
+              <DownloadResumeButton className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-70 disabled:cursor-wait text-white rounded-lg font-medium transition-all duration-300 hover:shadow-xl hover:shadow-indigo-500/30">
+                Download CV
+              </DownloadResumeButton>
+            </MagneticButton>
+            <MagneticButton>
+              <a
+                href="#projects"
+                className="block px-8 py-3 border border-indigo-500/60 dark:border-indigo-500/40 hover:border-indigo-400 text-slate-700 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-white rounded-lg font-medium transition-all duration-300 hover:bg-indigo-500/10"
+              >
+                View Projects
+              </a>
+            </MagneticButton>
           </motion.div>
         </div>
 

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -81,14 +81,22 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
       className={`group rounded-2xl overflow-hidden bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 ${project.border} transition-colors duration-300 shadow-xl ${project.glow}`}
     >
       <div className="relative h-52 overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent z-10 group-hover:opacity-60 transition-opacity duration-300" />
+        {/* gradient overlay fades on hover to reveal more of the image */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-black/10 z-10 group-hover:from-black/30 group-hover:via-black/10 group-hover:to-transparent transition-all duration-500" />
         <Image
           src={imgSrc(project.image)}
           alt={project.title}
           fill
-          className="object-cover group-hover:scale-110 transition-transform duration-700"
+          className="object-cover group-hover:scale-105 transition-transform duration-700"
           unoptimized
         />
+        {/* "Live preview" badge slides in on hover */}
+        <div className="absolute top-3 right-3 z-20 translate-y-[-6px] opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-300">
+          <span className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/60 backdrop-blur-sm border border-white/20 text-white text-xs font-medium">
+            <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+            Live
+          </span>
+        </div>
       </div>
 
       <div className="p-6">

--- a/components/SocialSidebar.tsx
+++ b/components/SocialSidebar.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { FaGithub, FaLinkedinIn, FaStackOverflow } from 'react-icons/fa'
+import { HiMail } from 'react-icons/hi'
+
+const links = [
+  { icon: FaGithub,        href: 'https://github.com/SurajFc',                           label: 'GitHub' },
+  { icon: FaLinkedinIn,    href: 'https://linkedin.com/in/suraj4',                        label: 'LinkedIn' },
+  { icon: FaStackOverflow, href: 'https://stackoverflow.com/users/12359814/surajfc',      label: 'Stack Overflow' },
+  { icon: HiMail,          href: 'mailto:surajthapafc@gmail.com',                         label: 'Email' },
+]
+
+export default function SocialSidebar() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const handler = () => setVisible(window.scrollY > 300)
+    window.addEventListener('scroll', handler, { passive: true })
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.aside
+          initial={{ opacity: 0, x: -16 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -16 }}
+          transition={{ duration: 0.3 }}
+          className="fixed left-5 bottom-1/3 z-40 hidden lg:flex flex-col items-center gap-3"
+        >
+          {links.map(({ icon: Icon, href, label }, i) => (
+            <motion.a
+              key={label}
+              href={href}
+              target={label !== 'Email' ? '_blank' : undefined}
+              rel="noopener noreferrer"
+              aria-label={label}
+              initial={{ opacity: 0, x: -10 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: i * 0.07 }}
+              whileHover={{ scale: 1.15, y: -2 }}
+              className="w-9 h-9 rounded-lg flex items-center justify-center text-slate-500 dark:text-slate-400 hover:text-indigo-500 dark:hover:text-indigo-400 border border-black/10 dark:border-white/10 hover:border-indigo-500/40 bg-white/80 dark:bg-black/40 backdrop-blur-sm transition-colors duration-200 shadow-sm"
+            >
+              <Icon className="w-[15px] h-[15px]" />
+            </motion.a>
+          ))}
+          <div className="w-px h-14 bg-gradient-to-b from-indigo-500/40 to-transparent mt-1" />
+        </motion.aside>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/lib/useMagnetic.ts
+++ b/lib/useMagnetic.ts
@@ -1,0 +1,18 @@
+import { useMotionValue, useSpring } from 'framer-motion'
+import type { MouseEvent } from 'react'
+
+export function useMagnetic(strength = 0.35) {
+  const x = useMotionValue(0)
+  const y = useMotionValue(0)
+  const springX = useSpring(x, { stiffness: 150, damping: 15, mass: 0.1 })
+  const springY = useSpring(y, { stiffness: 150, damping: 15, mass: 0.1 })
+
+  const onMouseMove = (e: MouseEvent<HTMLElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect()
+    x.set((e.clientX - (rect.left + rect.width / 2)) * strength)
+    y.set((e.clientY - (rect.top + rect.height / 2)) * strength)
+  }
+  const onMouseLeave = () => { x.set(0); y.set(0) }
+
+  return { style: { x: springX, y: springY }, onMouseMove, onMouseLeave }
+}


### PR DESCRIPTION
## Summary

6 UI enhancements in one shot:

### 1. Magnetic buttons
Hero CTAs (Download CV, View Projects) physically attract toward the cursor within their bounds. Built on a reusable `useMagnetic` hook with Framer Motion spring physics (stiffness 150, damping 15, strength 0.35). Snaps back smoothly on mouse leave.

### 2. Animated gradient mesh
3 slow-floating color blobs fixed behind all page content — indigo (22s), purple (28s), pink (18s). Very subtle opacity (7–12%) so they add depth without competing with content. CSS keyframe animations via `GradientMesh` component.

### 3. Grain/noise texture overlay
SVG `feTurbulence` filter at ~2–4% opacity adds a tactile, premium texture to the background. Popular in high-end 2024–25 design. `GrainOverlay` component, slightly stronger in dark mode.

### 4. Stat counters (About section)
Numbers upgraded from `text-4xl` to `text-5xl` with a 3-stop indigo→purple→pink gradient. Added `tabular-nums` so the width stays stable during the count-up animation.

### 5. Project image preview
Hover now fades the gradient overlay to reveal more of the screenshot, plus an animated pulsing "● Live" badge slides in from the top-right corner.

### 6. Floating social sidebar
GitHub, LinkedIn, Stack Overflow, Email icons appear fixed on the left side after scrolling 300px — desktop (`lg+`) only. Staggered entrance animation, hover lifts each icon slightly.

## Test plan

- [ ] Hover over hero buttons — they should move toward the cursor and snap back
- [ ] Social sidebar appears on desktop after scrolling past hero
- [ ] Project cards show "Live" badge and cleaner image on hover
- [ ] About stats count up with larger gradient numbers
- [ ] Subtle grain texture visible on both light and dark mode backgrounds
- [ ] Gradient blobs slowly animate in background

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_