### PR TITLE
Fix mobile x-overflow and unequal hero button widths

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,6 +20,7 @@
 
 html {
   scroll-behavior: auto;
+  overflow-x: clip; /* clip (not hidden) so position:fixed children still work */
 }
 
 body {

--- a/components/GradientMesh.tsx
+++ b/components/GradientMesh.tsx
@@ -1,6 +1,6 @@
 export default function GradientMesh() {
   return (
-    <div aria-hidden className="fixed inset-0 -z-10 pointer-events-none overflow-hidden">
+    <div aria-hidden className="fixed inset-0 -z-10 pointer-events-none" style={{ overflow: 'clip' }}>
       <div className="absolute w-[700px] h-[700px] rounded-full bg-indigo-600/[0.07] dark:bg-indigo-600/[0.12] blur-[100px] animate-mesh1 -top-40 -left-40" />
       <div className="absolute w-[600px] h-[600px] rounded-full bg-purple-600/[0.07] dark:bg-purple-600/[0.10] blur-[100px] animate-mesh2 -bottom-40 -right-40" />
       <div className="absolute w-[500px] h-[500px] rounded-full bg-pink-600/[0.05] dark:bg-pink-600/[0.08] blur-[80px] animate-mesh3 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -48,7 +48,7 @@ function Typewriter() {
 function MagneticButton({ children }: { children: React.ReactNode }) {
   const mag = useMagnetic(0.35)
   return (
-    <motion.div style={mag.style} onMouseMove={mag.onMouseMove} onMouseLeave={mag.onMouseLeave}>
+    <motion.div style={mag.style} onMouseMove={mag.onMouseMove} onMouseLeave={mag.onMouseLeave} className="w-full sm:w-auto">
       {children}
     </motion.div>
   )
@@ -85,7 +85,7 @@ export default function Hero() {
       className="relative min-h-screen flex flex-col justify-center overflow-hidden"
     >
       {/* Gradient orbs */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden">
+      <div className="absolute inset-0 pointer-events-none" style={{ overflow: 'clip' }}>
         <div className="absolute top-1/4 -left-20 w-[500px] h-[500px] bg-indigo-600/20 rounded-full blur-[120px] animate-pulse-slow" />
         <div
           className="absolute bottom-1/4 -right-20 w-[500px] h-[500px] bg-purple-600/20 rounded-full blur-[120px] animate-pulse-slow"
@@ -158,14 +158,14 @@ export default function Hero() {
             className="flex flex-col sm:flex-row gap-4 justify-center"
           >
             <MagneticButton>
-              <DownloadResumeButton className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-70 disabled:cursor-wait text-white rounded-lg font-medium transition-all duration-300 hover:shadow-xl hover:shadow-indigo-500/30">
+              <DownloadResumeButton className="w-full sm:w-auto px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-70 disabled:cursor-wait text-white rounded-lg font-medium transition-all duration-300 hover:shadow-xl hover:shadow-indigo-500/30">
                 Download CV
               </DownloadResumeButton>
             </MagneticButton>
             <MagneticButton>
               <a
                 href="#projects"
-                className="block px-8 py-3 border border-indigo-500/60 dark:border-indigo-500/40 hover:border-indigo-400 text-slate-700 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-white rounded-lg font-medium transition-all duration-300 hover:bg-indigo-500/10"
+                className="block w-full sm:w-auto text-center px-8 py-3 border border-indigo-500/60 dark:border-indigo-500/40 hover:border-indigo-400 text-slate-700 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-white rounded-lg font-medium transition-all duration-300 hover:bg-indigo-500/10"
               >
                 View Projects
               </a>


### PR DESCRIPTION
## Summary

### Mobile x-overflow
`filter: blur()` visually bleeds past an element's painted box, and `overflow: hidden` doesn't clip filter effects on all mobile browsers. Switched `GradientMesh` and Hero orbs containers from `overflow: hidden` to `overflow: clip`, which clips filter bleed too. Added `overflow-x: clip` to `html` as a root-level catch-all — uses `clip` not `hidden` so `position: fixed` elements continue to work correctly.

### Button widths
The `MagneticButton` `motion.div` wrapper didn't stretch on mobile, so "Download CV" (inline button) was narrower than "View Projects" (block anchor). Both wrappers and inner elements now use `w-full sm:w-auto` so they stack at equal full-width on mobile.

## Test plan

- [ ] No horizontal scroll/overflow on mobile
- [ ] "Download CV" and "View Projects" buttons same width on mobile
- [ ] Gradient blobs don't bleed outside viewport on any screen size
- [ ] Desktop layout unchanged

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_