### PR TITLE
SEO: fix canonical URL, add sitemap.xml and robots.txt

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,10 +15,10 @@ import './globals.css'
 const inter = Inter({ subsets: ['latin'] })
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
-const SITE_URL = 'https://surajfc.github.io/surajPortfolio'
+const SITE_URL = 'https://surajthapa.vercel.app'
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://surajfc.github.io'),
+  metadataBase: new URL('https://surajthapa.vercel.app'),
 
   title: {
     default: 'Suraj Thapa | Software Engineer',
@@ -115,6 +115,7 @@ const jsonLd = {
     'https://github.com/SurajFc',
     'https://www.linkedin.com/in/suraj4/',
     'https://stackoverflow.com/users/12359814/surajfc',
+    'https://surajfc.github.io/surajPortfolio',
   ],
   knowsAbout: [
     'JavaScript', 'TypeScript', 'React', 'React Native',

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://surajthapa.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://surajthapa.vercel.app/</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

### Canonical URL fix
`SITE_URL` and `metadataBase` were pointing to `surajfc.github.io/surajPortfolio`. Google was seeing two URLs serving identical content and splitting the ranking signal. Now canonicalised to `https://surajthapa.vercel.app` (primary domain). GitHub Pages URL added to JSON-LD `sameAs` so Google understands both are the same person.

### sitemap.xml
Added `public/sitemap.xml` with the Vercel URL, `changefreq: monthly`, `priority: 1.0`. Referenced in `robots.txt` so Google finds it automatically.

### robots.txt
Added `public/robots.txt` — allows all crawlers, points to sitemap.

## After merging — manual steps to rank faster

1. **Google Search Console** → go to [search.google.com/search-console](https://search.google.com/search-console), add `https://surajthapa.vercel.app`, verify via Vercel DNS TXT record, then submit `https://surajthapa.vercel.app/sitemap.xml`
2. **LinkedIn** → Settings → Edit profile → Website → add `https://surajthapa.vercel.app`
3. **GitHub profile** → Edit profile → Website → add `https://surajthapa.vercel.app`
4. **Stack Overflow** → Edit profile → Website → add `https://surajthapa.vercel.app`

These 3 profile backlinks + Search Console submission are the biggest ranking factors for a name search.

## Test plan

- [ ] `https://surajthapa.vercel.app/sitemap.xml` returns valid XML after deploy
- [ ] `https://surajthapa.vercel.app/robots.txt` accessible
- [ ] Page `<link rel="canonical">` points to `https://surajthapa.vercel.app/`

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_