### PR TITLE
Add Google Search Console verification meta tag

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -100,6 +100,10 @@ export const metadata: Metadata = {
   },
 
   category: 'technology',
+
+  verification: {
+    google: '7bi6x19w37NjyW5rILmQ2S3-_ScRxoCal5pHlFfP3Ls',
+  },
 }
 
 // JSON-LD structured data — helps Google understand the page as a Person entity


### PR DESCRIPTION
## Summary

Adds Google Search Console ownership verification meta tag via Next.js `metadata.verification.google`. This renders as:

```html
<meta name="google-site-verification" content="7bi6x19w37NjyW5rILmQ2S3-_ScRxoCal5pHlFfP3Ls" />
```

## After merging

Once deployed, go to Google Search Console and click **Verify** — it will find the tag and verify instantly. Then submit the sitemap:
`https://surajthapa.vercel.app/sitemap.xml`

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_