### PR TITLE
Stop terminal focus from scrolling page to About

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -153,7 +153,7 @@ export default function Terminal() {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, delay: 1.4 }}
       className="block w-full max-w-2xl mx-auto mt-8 sm:mt-10"
-      onClick={() => inputRef.current?.focus()}
+      onClick={() => inputRef.current?.focus({ preventScroll: true })}
     >
       {/* Title bar */}
       <div className="flex items-center gap-2 px-4 py-2.5 bg-zinc-800 rounded-t-xl border border-white/10 border-b-0">


### PR DESCRIPTION
## Summary

Clicking into / focusing the terminal input triggered the browser's native "scroll focused element into view" behavior. Since the terminal sits at the bottom of the full-height hero section, focusing it scrolled the page down to where it sits — right around the About section.

Fix: added `{ preventScroll: true }` to the `focus()` call so focusing the terminal input no longer moves the page. The terminal still scrolls its own content internally as before.

## Test plan

- [ ] Click into the terminal and type — page should not jump to About
- [ ] Terminal output still scrolls within its own body
- [ ] Works on both mobile and desktop

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_