### PR TITLE
Add Balajee ERP & Edunaa projects with See More modal

### DIFF
--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,12 +1,23 @@
 'use client'
 
-import { useRef } from 'react'
-import { motion, useInView, useMotionValue, useSpring, useTransform } from 'framer-motion'
+import { useRef, useState } from 'react'
+import { motion, useInView, useMotionValue, useSpring, useTransform, AnimatePresence } from 'framer-motion'
 import Image from 'next/image'
 import SectionHeading from './SectionHeading'
 import { imgSrc } from '@/lib/imgSrc'
 
-const projects = [
+type Project = {
+  title: string
+  image: string
+  tech: string[]
+  description: string
+  link: string
+  glow: string
+  border: string
+  badge: string
+}
+
+const projects: Project[] = [
   {
     title: 'WellPro',
     image: '/images/wellpro.svg',
@@ -53,7 +64,32 @@ const projects = [
   },
 ]
 
-function ProjectCard({ project, index }: { project: (typeof projects)[0]; index: number }) {
+const moreProjects: Project[] = [
+  {
+    title: 'Balajee ERP',
+    image: '/images/balajee.svg',
+    tech: ['React', 'TypeScript', 'Turborepo', 'Tailwind v4', 'shadcn/ui'],
+    description:
+      'Enterprise resource planning system built for Balajee Glass Industries. A Turborepo monorepo with Vite + React + TypeScript powering estimate generation, production-order management, inventory tracking, and real-time workflow dashboards — all within a modern shadcn/ui interface.',
+    link: '#',
+    glow: 'group-hover:shadow-cyan-500/20',
+    border: 'hover:border-cyan-500/40',
+    badge: 'bg-cyan-500/10 text-cyan-300 border-cyan-500/20',
+  },
+  {
+    title: 'Edunaa',
+    image: '/images/edunaa.svg',
+    tech: ['ReactJS', 'Django', 'AWS', 'Stripe', 'Video.js', 'Redux'],
+    description:
+      'An educational marketplace for East Africa connecting learners with course content via video streaming, progress tracking, and quiz participation. Features certificate generation, social logins, and a fully integrated Stripe payments flow backed by a Django REST API with AWS media delivery.',
+    link: '#',
+    glow: 'group-hover:shadow-pink-500/20',
+    border: 'hover:border-pink-500/40',
+    badge: 'bg-pink-500/10 text-pink-300 border-pink-500/20',
+  },
+]
+
+function ProjectCard({ project, index }: { project: Project; index: number }) {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-80px' })
 
@@ -81,7 +117,6 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
       className={`group rounded-2xl overflow-hidden bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 ${project.border} transition-colors duration-300 shadow-xl ${project.glow}`}
     >
       <div className="relative h-52 overflow-hidden">
-        {/* gradient overlay fades on hover to reveal more of the image */}
         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-black/10 z-10 group-hover:from-black/30 group-hover:via-black/10 group-hover:to-transparent transition-all duration-500" />
         <Image
           src={imgSrc(project.image)}
@@ -90,13 +125,14 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
           className="object-cover group-hover:scale-105 transition-transform duration-700"
           unoptimized
         />
-        {/* "Live preview" badge slides in on hover */}
-        <div className="absolute top-3 right-3 z-20 translate-y-[-6px] opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-300">
-          <span className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/60 backdrop-blur-sm border border-white/20 text-white text-xs font-medium">
-            <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
-            Live
-          </span>
-        </div>
+        {project.link !== '#' && (
+          <div className="absolute top-3 right-3 z-20 translate-y-[-6px] opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-300">
+            <span className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-black/60 backdrop-blur-sm border border-white/20 text-white text-xs font-medium">
+              <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+              Live
+            </span>
+          </div>
+        )}
       </div>
 
       <div className="p-6">
@@ -104,15 +140,12 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
         <p className="text-slate-600 dark:text-slate-400 text-sm leading-relaxed mb-4">{project.description}</p>
         <div className="flex flex-wrap gap-2 mb-5">
           {project.tech.map((t) => (
-            <span
-              key={t}
-              className={`text-xs px-2.5 py-1 rounded-full border ${project.badge}`}
-            >
+            <span key={t} className={`text-xs px-2.5 py-1 rounded-full border ${project.badge}`}>
               {t}
             </span>
           ))}
         </div>
-        {project.link !== '#' && (
+        {project.link !== '#' ? (
           <a
             href={project.link}
             target="_blank"
@@ -122,11 +155,88 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
             View Project
             <span className="group-hover/link:translate-x-1 transition-transform">→</span>
           </a>
-        )}
-        {project.link === '#' && (
-          <span className="text-sm text-slate-600 italic">Coming soon</span>
+        ) : (
+          <span className="text-sm text-slate-500 dark:text-slate-600 italic">Private / Internal</span>
         )}
       </div>
+    </motion.div>
+  )
+}
+
+function MoreProjectsModal({ onClose }: { onClose: () => void }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6"
+      onClick={onClose}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+
+      {/* Panel */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 16 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 16 }}
+        transition={{ duration: 0.25 }}
+        className="relative z-10 w-full max-w-4xl max-h-[90vh] overflow-y-auto rounded-2xl bg-white dark:bg-zinc-900 border border-black/10 dark:border-white/10 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-black/10 dark:border-white/10 sticky top-0 bg-white dark:bg-zinc-900 z-10">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">More Projects</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400 mt-0.5">Additional work & side projects</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg text-slate-500 hover:text-slate-900 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+            aria-label="Close modal"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Project grid */}
+        <div className="p-6 grid sm:grid-cols-2 gap-6">
+          {moreProjects.map((project, i) => (
+            <motion.div
+              key={project.title}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.35, delay: i * 0.1 }}
+              className={`group rounded-2xl overflow-hidden bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 ${project.border} transition-colors duration-300 shadow-lg ${project.glow}`}
+            >
+              <div className="relative h-44 overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-black/10 z-10 group-hover:from-black/30 group-hover:via-black/10 group-hover:to-transparent transition-all duration-500" />
+                <Image
+                  src={imgSrc(project.image)}
+                  alt={project.title}
+                  fill
+                  className="object-cover group-hover:scale-105 transition-transform duration-700"
+                  unoptimized
+                />
+              </div>
+              <div className="p-5">
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">{project.title}</h3>
+                <p className="text-slate-600 dark:text-slate-400 text-sm leading-relaxed mb-4">{project.description}</p>
+                <div className="flex flex-wrap gap-2">
+                  {project.tech.map((t) => (
+                    <span key={t} className={`text-xs px-2.5 py-1 rounded-full border ${project.badge}`}>
+                      {t}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </motion.div>
     </motion.div>
   )
 }
@@ -134,6 +244,7 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
 export default function Projects() {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-100px' })
+  const [modalOpen, setModalOpen] = useState(false)
 
   return (
     <section id="projects" className="py-24 px-4 bg-white/[0.02]">
@@ -152,7 +263,31 @@ export default function Projects() {
             <ProjectCard key={project.title} project={project} index={i} />
           ))}
         </div>
+
+        {/* See More button */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={isInView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.5, delay: 0.4 }}
+          className="mt-10 flex justify-center"
+        >
+          <button
+            onClick={() => setModalOpen(true)}
+            className="group inline-flex items-center gap-2 px-6 py-3 rounded-full border border-indigo-500/40 text-indigo-400 hover:text-indigo-300 hover:border-indigo-400/70 hover:bg-indigo-500/10 transition-all duration-300 text-sm font-medium"
+          >
+            See More Projects
+            <span className="group-hover:rotate-90 transition-transform duration-300">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+            </span>
+          </button>
+        </motion.div>
       </div>
+
+      <AnimatePresence>
+        {modalOpen && <MoreProjectsModal onClose={() => setModalOpen(false)} />}
+      </AnimatePresence>
     </section>
   )
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/public/images/balajee.svg
+++ b/public/images/balajee.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0e1117"/>
+      <stop offset="100%" style="stop-color:#0f1f2e"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#06b6d4"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <!-- Grid lines -->
+  <g stroke="#ffffff08" stroke-width="1">
+    <line x1="0" y1="90" x2="800" y2="90"/>
+    <line x1="0" y1="180" x2="800" y2="180"/>
+    <line x1="0" y1="270" x2="800" y2="270"/>
+    <line x1="0" y1="360" x2="800" y2="360"/>
+    <line x1="160" y1="0" x2="160" y2="450"/>
+    <line x1="320" y1="0" x2="320" y2="450"/>
+    <line x1="480" y1="0" x2="480" y2="450"/>
+    <line x1="640" y1="0" x2="640" y2="450"/>
+  </g>
+  <!-- Dashboard cards -->
+  <rect x="60" y="60" width="200" height="100" rx="12" fill="#ffffff06" stroke="#06b6d422" stroke-width="1"/>
+  <rect x="60" y="60" width="200" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="95" font-family="monospace" font-size="11" fill="#94a3b8">Total Orders</text>
+  <text x="80" y="125" font-family="monospace" font-size="28" font-weight="bold" fill="#06b6d4">1,284</text>
+
+  <rect x="290" y="60" width="200" height="100" rx="12" fill="#ffffff06" stroke="#06b6d422" stroke-width="1"/>
+  <rect x="290" y="60" width="200" height="4" rx="2" fill="url(#accent)"/>
+  <text x="310" y="95" font-family="monospace" font-size="11" fill="#94a3b8">Estimates</text>
+  <text x="310" y="125" font-family="monospace" font-size="28" font-weight="bold" fill="#06b6d4">347</text>
+
+  <rect x="520" y="60" width="200" height="100" rx="12" fill="#ffffff06" stroke="#06b6d422" stroke-width="1"/>
+  <rect x="520" y="60" width="200" height="4" rx="2" fill="url(#accent)"/>
+  <text x="540" y="95" font-family="monospace" font-size="11" fill="#94a3b8">Production</text>
+  <text x="540" y="125" font-family="monospace" font-size="28" font-weight="bold" fill="#06b6d4">92%</text>
+
+  <!-- Bar chart -->
+  <rect x="60" y="190" width="460" height="200" rx="12" fill="#ffffff06" stroke="#06b6d415" stroke-width="1"/>
+  <text x="80" y="218" font-family="monospace" font-size="11" fill="#94a3b8">Monthly Production Orders</text>
+  <rect x="90" y="340" width="30" height="30" rx="3" fill="#06b6d440"/>
+  <rect x="140" y="310" width="30" height="60" rx="3" fill="#06b6d460"/>
+  <rect x="190" y="280" width="30" height="90" rx="3" fill="#06b6d480"/>
+  <rect x="240" y="250" width="30" height="120" rx="3" fill="#06b6d4a0"/>
+  <rect x="290" y="270" width="30" height="100" rx="3" fill="#06b6d480"/>
+  <rect x="340" y="240" width="30" height="130" rx="3" fill="#06b6d4c0"/>
+  <rect x="390" y="260" width="30" height="110" rx="3" fill="#06b6d4a0"/>
+  <rect x="440" y="230" width="30" height="140" rx="3" fill="#06b6d4"/>
+
+  <!-- Label -->
+  <text x="400" y="420" font-family="monospace" font-size="13" fill="#64748b" text-anchor="middle">Balajee Glass Industries — ERP Platform</text>
+</svg>

--- a/public/images/edunaa.svg
+++ b/public/images/edunaa.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#130d1a"/>
+      <stop offset="100%" style="stop-color:#1a0d2e"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#a855f7"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <!-- Subtle grid -->
+  <g stroke="#ffffff05" stroke-width="1">
+    <line x1="0" y1="90" x2="800" y2="90"/>
+    <line x1="0" y1="180" x2="800" y2="180"/>
+    <line x1="0" y1="270" x2="800" y2="270"/>
+    <line x1="0" y1="360" x2="800" y2="360"/>
+    <line x1="200" y1="0" x2="200" y2="450"/>
+    <line x1="400" y1="0" x2="400" y2="450"/>
+    <line x1="600" y1="0" x2="600" y2="450"/>
+  </g>
+  <!-- Hero nav bar -->
+  <rect x="40" y="20" width="720" height="50" rx="10" fill="#ffffff08"/>
+  <rect x="60" y="33" width="80" height="24" rx="6" fill="url(#accent)" opacity="0.8"/>
+  <text x="100" y="50" font-family="sans-serif" font-size="12" fill="white" text-anchor="middle" font-weight="bold">edunaa</text>
+  <rect x="500" y="37" width="60" height="16" rx="8" fill="#ffffff10"/>
+  <rect x="570" y="37" width="60" height="16" rx="8" fill="#ffffff10"/>
+  <rect x="640" y="37" width="80" height="16" rx="8" fill="url(#accent)" opacity="0.6"/>
+
+  <!-- Video player -->
+  <rect x="40" y="90" width="460" height="260" rx="12" fill="#000000a0" stroke="#ec489930" stroke-width="1"/>
+  <rect x="40" y="90" width="460" height="3" rx="2" fill="url(#accent)"/>
+  <!-- Play button -->
+  <circle cx="270" cy="215" r="32" fill="#ec489940" stroke="#ec489980" stroke-width="2"/>
+  <polygon points="260,200 260,230 290,215" fill="#ec4899"/>
+  <!-- Progress bar -->
+  <rect x="60" y="328" width="420" height="4" rx="2" fill="#ffffff15"/>
+  <rect x="60" y="328" width="200" height="4" rx="2" fill="url(#accent)"/>
+  <text x="60" y="350" font-family="monospace" font-size="10" fill="#94a3b8">Advanced React Patterns — Module 4</text>
+
+  <!-- Course list sidebar -->
+  <rect x="520" y="90" width="240" height="260" rx="12" fill="#ffffff06" stroke="#a855f720" stroke-width="1"/>
+  <text x="540" y="118" font-family="sans-serif" font-size="11" fill="#94a3b8">Your Courses</text>
+  <rect x="540" y="128" width="200" height="40" rx="8" fill="#ec489920"/>
+  <rect x="540" y="176" width="200" height="40" rx="8" fill="#ffffff08"/>
+  <rect x="540" y="224" width="200" height="40" rx="8" fill="#ffffff08"/>
+  <rect x="540" y="272" width="200" height="40" rx="8" fill="#ffffff08"/>
+  <!-- Progress bars in courses -->
+  <rect x="550" y="158" width="180" height="3" rx="1" fill="#ffffff10"/>
+  <rect x="550" y="158" width="140" height="3" rx="1" fill="#ec4899"/>
+  <rect x="550" y="206" width="180" height="3" rx="1" fill="#ffffff10"/>
+  <rect x="550" y="206" width="80" height="3" rx="1" fill="#a855f7"/>
+  <rect x="550" y="254" width="180" height="3" rx="1" fill="#ffffff10"/>
+  <rect x="550" y="254" width="50" height="3" rx="1" fill="#a855f7"/>
+
+  <!-- Bottom stats -->
+  <rect x="40" y="368" width="200" height="50" rx="10" fill="#ffffff06"/>
+  <text x="60" y="390" font-family="monospace" font-size="10" fill="#94a3b8">Courses Completed</text>
+  <text x="60" y="408" font-family="monospace" font-size="18" font-weight="bold" fill="#ec4899">24</text>
+
+  <rect x="260" y="368" width="200" height="50" rx="10" fill="#ffffff06"/>
+  <text x="280" y="390" font-family="monospace" font-size="10" fill="#94a3b8">Certificates Earned</text>
+  <text x="280" y="408" font-family="monospace" font-size="18" font-weight="bold" fill="#a855f7">8</text>
+
+  <rect x="480" y="368" width="280" height="50" rx="10" fill="#ffffff06"/>
+  <text x="500" y="390" font-family="monospace" font-size="10" fill="#94a3b8">Platform — East Africa</text>
+  <text x="500" y="408" font-family="monospace" font-size="18" font-weight="bold" fill="#ec4899">Edunaa</text>
+</svg>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds **Balajee ERP** — Turborepo monorepo ERP system for Balajee Glass Industries (React, TypeScript, Tailwind v4, shadcn/ui). Marked as Private/Internal since the repo is private.
- Adds **Edunaa** — Educational marketplace for East Africa (ReactJS, Django, AWS, Stripe, Video.js, Redux) with video streaming, progress tracking, quiz participation, and certificate generation.
- Adds a **"See More Projects"** button below the existing 4-card grid that opens an animated modal displaying the two additional projects.
- Custom SVG placeholder images created for both new projects matching their colour themes (cyan for Balajee ERP, pink/purple for Edunaa).

## Test plan

- [ ] Click "See More Projects" button — modal opens with both new project cards
- [ ] Click outside modal or the × button — modal closes
- [ ] Both cards display description, tech badges, and SVG image correctly
- [ ] Existing 4 project cards are unchanged
- [ ] "Live" badge only appears on projects with real links (not on Balajee ERP / Edunaa)
- [ ] Modal scrolls independently on smaller screens

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_