### PR TITLE
Restructure projects & add GitHub stats section

### DIFF
--- a/components/GitHubActivity.tsx
+++ b/components/GitHubActivity.tsx
@@ -1,5 +1,6 @@
 import SectionHeading from './SectionHeading'
 import RepoCards from './RepoCards'
+import GitHubStatPills from './GitHubStatPills'
 import { FaGithub } from 'react-icons/fa'
 
 interface Repo {
@@ -13,7 +14,12 @@ interface Repo {
   updated_at: string
 }
 
-// Update this list to match your pinned repos on github.com/SurajFc
+interface GitHubProfile {
+  public_repos: number
+  followers: number
+  following: number
+}
+
 const PINNED_REPOS = [
   'surajPortfolio',
   'smart-on-fhir-app',
@@ -23,12 +29,14 @@ const PINNED_REPOS = [
   'Django-JWT-boilerplate',
 ]
 
+const GH_HEADERS = { Accept: 'application/vnd.github+json' }
+
 async function fetchRepos(): Promise<Repo[]> {
   try {
     const results = await Promise.all(
       PINNED_REPOS.map((name) =>
         fetch(`https://api.github.com/repos/SurajFc/${name}`, {
-          headers: { Accept: 'application/vnd.github+json' },
+          headers: GH_HEADERS,
           cache: 'force-cache',
         }).then((r) => (r.ok ? (r.json() as Promise<Repo>) : null))
       )
@@ -39,10 +47,28 @@ async function fetchRepos(): Promise<Repo[]> {
   }
 }
 
+async function fetchProfile(): Promise<GitHubProfile | null> {
+  try {
+    const r = await fetch('https://api.github.com/users/SurajFc', {
+      headers: GH_HEADERS,
+      cache: 'force-cache',
+    })
+    return r.ok ? (r.json() as Promise<GitHubProfile>) : null
+  } catch {
+    return null
+  }
+}
+
+// Shared query params for all github-readme-stats images
+const GRS_BASE = 'https://github-readme-stats.vercel.app/api'
+const GRS_PARAMS = 'theme=transparent&hide_border=true&title_color=6366f1&icon_color=6366f1&text_color=64748b&bg_color=00000000'
 
 export default async function GitHubActivity() {
-  const repos = await fetchRepos()
+  const [repos, profile] = await Promise.all([fetchRepos(), fetchProfile()])
   if (repos.length === 0) return null
+
+  const totalStars = repos.reduce((acc, r) => acc + r.stargazers_count, 0)
+  const totalForks = repos.reduce((acc, r) => acc + r.forks_count, 0)
 
   return (
     <section className="py-24 px-4 bg-black/[0.02] dark:bg-white/[0.02]">
@@ -51,16 +77,59 @@ export default async function GitHubActivity() {
           <SectionHeading number="07" title="GitHub Activity" />
         </div>
 
+        {/* Live stat pills */}
+        <GitHubStatPills
+          publicRepos={profile?.public_repos ?? repos.length}
+          totalStars={totalStars}
+          followers={profile?.followers ?? 0}
+          totalForks={totalForks}
+        />
+
+        {/* GitHub Stats + Top Languages */}
+        <div className="grid md:grid-cols-2 gap-4 mb-4">
+          <div className="p-4 rounded-xl bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 flex items-center justify-center overflow-hidden">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`${GRS_BASE}?username=SurajFc&show_icons=true&count_private=true&include_all_commits=true&${GRS_PARAMS}`}
+              alt="Suraj's GitHub stats"
+              className="w-full max-w-sm"
+              loading="lazy"
+            />
+          </div>
+          <div className="p-4 rounded-xl bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 flex items-center justify-center overflow-hidden">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`${GRS_BASE}/top-langs/?username=SurajFc&layout=compact&langs_count=8&${GRS_PARAMS}`}
+              alt="Suraj's top languages"
+              className="w-full max-w-sm"
+              loading="lazy"
+            />
+          </div>
+        </div>
+
+        {/* Streak Stats */}
+        <div className="p-4 rounded-xl bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 flex items-center justify-center overflow-hidden mb-10">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="https://streak-stats.demolab.com/?user=SurajFc&theme=transparent&hide_border=true&stroke=6366f1&ring=6366f1&fire=f97316&currStreakNum=64748b&sideNums=64748b&currStreakLabel=6366f1&sideLabels=64748b&dates=64748b&background=00000000"
+            alt="Suraj's GitHub streak stats"
+            className="w-full max-w-2xl"
+            loading="lazy"
+          />
+        </div>
+
+        {/* Pinned repo cards */}
         <RepoCards repos={repos} />
 
-        {/* Contribution graph */}
+        {/* Contribution activity graph */}
         <div className="mt-10 p-4 rounded-xl bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 overflow-hidden">
           <p className="text-xs text-slate-500 dark:text-slate-400 mb-3 font-medium">Contribution Activity</p>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src="https://ghchart.rshah.org/4f46e5/SurajFc"
-            alt="GitHub contribution graph for SurajFc"
+            src="https://github-activity-graph.vercel.app/graph?username=SurajFc&theme=react-dark&hide_border=true&area=true&bg_color=transparent&color=818cf8&line=6366f1&point=6366f1&area_color=6366f1"
+            alt="GitHub contribution activity graph for SurajFc"
             className="w-full rounded"
+            loading="lazy"
           />
         </div>
 

--- a/components/GitHubStatPills.tsx
+++ b/components/GitHubStatPills.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { FaGithub, FaStar, FaUsers, FaCode } from 'react-icons/fa'
+
+interface Props {
+  publicRepos: number
+  totalStars: number
+  followers: number
+  totalForks: number
+}
+
+const pills = [
+  { key: 'publicRepos', label: 'Public Repos', Icon: FaGithub, color: 'text-indigo-400' },
+  { key: 'totalStars', label: 'Total Stars', Icon: FaStar, color: 'text-yellow-400' },
+  { key: 'followers', label: 'Followers', Icon: FaUsers, color: 'text-emerald-400' },
+  { key: 'totalForks', label: 'Total Forks', Icon: FaCode, color: 'text-purple-400' },
+]
+
+export default function GitHubStatPills({ publicRepos, totalStars, followers, totalForks }: Props) {
+  const values = { publicRepos, totalStars, followers, totalForks }
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-10">
+      {pills.map(({ key, label, Icon, color }, i) => (
+        <motion.div
+          key={key}
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: i * 0.08 }}
+          className="flex flex-col items-center gap-2 py-5 px-4 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 hover:border-indigo-500/30 transition-colors"
+        >
+          <Icon className={`text-xl ${color}`} />
+          <span className="text-2xl font-bold text-slate-900 dark:text-white tabular-nums">
+            {values[key as keyof typeof values]}
+          </span>
+          <span className="text-xs text-slate-500 dark:text-slate-400 text-center">{label}</span>
+        </motion.div>
+      ))}
+    </div>
+  )
+}

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -30,15 +30,15 @@ const projects: Project[] = [
     badge: 'bg-orange-500/10 text-orange-300 border-orange-500/20',
   },
   {
-    title: 'PeriopMD',
-    image: '/images/PeriopMD.png',
-    tech: ['ReactJS', 'Redux', 'MaterialUI', 'Stripe'],
+    title: 'Balajee ERP',
+    image: '/images/balajee.svg',
+    tech: ['React', 'TypeScript', 'Turborepo', 'Tailwind v4', 'shadcn/ui'],
     description:
-      'A medical portal where hospitals and individual practitioners register via subscription. Provides test recommendations based on conditions and age, with custom test and condition creation.',
-    link: 'https://practitioner.periopmd.org',
-    glow: 'group-hover:shadow-blue-500/20',
-    border: 'hover:border-blue-500/40',
-    badge: 'bg-blue-500/10 text-blue-300 border-blue-500/20',
+      'Enterprise resource planning system built for Balajee Glass Industries. A Turborepo monorepo with Vite + React + TypeScript powering estimate generation, production-order management, inventory tracking, and real-time workflow dashboards — all within a modern shadcn/ui interface.',
+    link: '#',
+    glow: 'group-hover:shadow-cyan-500/20',
+    border: 'hover:border-cyan-500/40',
+    badge: 'bg-cyan-500/10 text-cyan-300 border-cyan-500/20',
   },
   {
     title: 'TTA Connect',
@@ -66,15 +66,26 @@ const projects: Project[] = [
 
 const moreProjects: Project[] = [
   {
-    title: 'Balajee ERP',
-    image: '/images/balajee.svg',
-    tech: ['React', 'TypeScript', 'Turborepo', 'Tailwind v4', 'shadcn/ui'],
+    title: 'OppVenuz',
+    image: '/images/oppvenuz.svg',
+    tech: ['ReactJS', 'React Native', 'TypeScript', 'Django', 'Firebase'],
     description:
-      'Enterprise resource planning system built for Balajee Glass Industries. A Turborepo monorepo with Vite + React + TypeScript powering estimate generation, production-order management, inventory tracking, and real-time workflow dashboards — all within a modern shadcn/ui interface.',
-    link: '#',
-    glow: 'group-hover:shadow-cyan-500/20',
-    border: 'hover:border-cyan-500/40',
-    badge: 'bg-cyan-500/10 text-cyan-300 border-cyan-500/20',
+      'A full-stack event planning marketplace connecting users with verified vendors — venues, caterers, decorators, and photographers. Features smart vendor matching, real-time chat, booking management, and vendor dashboards. Available on web, iOS, and Android.',
+    link: 'https://www.oppvenuz.com/',
+    glow: 'group-hover:shadow-yellow-500/20',
+    border: 'hover:border-yellow-500/40',
+    badge: 'bg-yellow-500/10 text-yellow-300 border-yellow-500/20',
+  },
+  {
+    title: 'PeriopMD',
+    image: '/images/PeriopMD.png',
+    tech: ['ReactJS', 'Redux', 'MaterialUI', 'Stripe'],
+    description:
+      'A medical portal where hospitals and individual practitioners register via subscription. Provides test recommendations based on conditions and age, with custom test and condition creation.',
+    link: 'https://practitioner.periopmd.org',
+    glow: 'group-hover:shadow-blue-500/20',
+    border: 'hover:border-blue-500/40',
+    badge: 'bg-blue-500/10 text-blue-300 border-blue-500/20',
   },
   {
     title: 'Edunaa',

--- a/public/images/oppvenuz.svg
+++ b/public/images/oppvenuz.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1200"/>
+      <stop offset="100%" style="stop-color:#1a0f00"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#eab308"/>
+      <stop offset="100%" style="stop-color:#f97316"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <!-- Grid -->
+  <g stroke="#ffffff05" stroke-width="1">
+    <line x1="0" y1="90" x2="800" y2="90"/>
+    <line x1="0" y1="180" x2="800" y2="180"/>
+    <line x1="0" y1="270" x2="800" y2="270"/>
+    <line x1="0" y1="360" x2="800" y2="360"/>
+    <line x1="200" y1="0" x2="200" y2="450"/>
+    <line x1="400" y1="0" x2="400" y2="450"/>
+    <line x1="600" y1="0" x2="600" y2="450"/>
+  </g>
+
+  <!-- Nav -->
+  <rect x="40" y="18" width="720" height="48" rx="10" fill="#ffffff08"/>
+  <rect x="58" y="30" width="100" height="24" rx="6" fill="url(#accent)" opacity="0.85"/>
+  <text x="108" y="47" font-family="sans-serif" font-size="12" fill="white" text-anchor="middle" font-weight="bold">OppVenuz</text>
+  <rect x="480" y="34" width="80" height="14" rx="7" fill="#ffffff10"/>
+  <rect x="572" y="34" width="80" height="14" rx="7" fill="#ffffff10"/>
+  <rect x="664" y="32" width="76" height="18" rx="9" fill="url(#accent)" opacity="0.7"/>
+
+  <!-- Hero search bar -->
+  <rect x="120" y="85" width="560" height="52" rx="26" fill="#ffffff0d" stroke="#eab30830" stroke-width="1.5"/>
+  <circle cx="160" cy="111" r="14" fill="#eab30820"/>
+  <text x="152" y="116" font-family="sans-serif" font-size="14" fill="#eab308">⌕</text>
+  <rect x="185" y="103" width="280" height="16" rx="4" fill="#ffffff10"/>
+  <rect x="575" y="101" width="82" height="20" rx="10" fill="url(#accent)" opacity="0.8"/>
+
+  <!-- Vendor cards -->
+  <rect x="40" y="160" width="165" height="180" rx="14" fill="#ffffff08" stroke="#eab30820" stroke-width="1"/>
+  <rect x="40" y="160" width="165" height="80" rx="14" fill="#eab30815"/>
+  <rect x="40" y="220" width="165" height="20" rx="0" fill="#eab30815"/>
+  <text x="68" y="216" font-family="sans-serif" font-size="10" fill="#94a3b8">📍 Pune, MH</text>
+  <text x="55" y="252" font-family="sans-serif" font-size="11" font-weight="bold" fill="#f1f5f9">Royal Banquet Hall</text>
+  <text x="55" y="268" font-family="sans-serif" font-size="10" fill="#94a3b8">Venue · ₹80,000/event</text>
+  <rect x="55" y="278" width="60" height="14" rx="7" fill="#eab30820"/>
+  <text x="85" y="289" font-family="sans-serif" font-size="9" fill="#eab308" text-anchor="middle">★ 4.8</text>
+  <rect x="55" y="302" width="130" height="22" rx="11" fill="url(#accent)" opacity="0.7"/>
+  <text x="120" y="317" font-family="sans-serif" font-size="10" fill="white" text-anchor="middle">Book Now</text>
+
+  <rect x="220" y="160" width="165" height="180" rx="14" fill="#ffffff08" stroke="#eab30820" stroke-width="1"/>
+  <rect x="220" y="160" width="165" height="80" rx="14" fill="#f9731615"/>
+  <rect x="220" y="220" width="165" height="20" rx="0" fill="#f9731615"/>
+  <text x="248" y="216" font-family="sans-serif" font-size="10" fill="#94a3b8">📍 Mumbai, MH</text>
+  <text x="235" y="252" font-family="sans-serif" font-size="11" font-weight="bold" fill="#f1f5f9">The Decor Studio</text>
+  <text x="235" y="268" font-family="sans-serif" font-size="10" fill="#94a3b8">Decorator · ₹40,000</text>
+  <rect x="235" y="278" width="60" height="14" rx="7" fill="#f9731620"/>
+  <text x="265" y="289" font-family="sans-serif" font-size="9" fill="#f97316" text-anchor="middle">★ 4.6</text>
+  <rect x="235" y="302" width="130" height="22" rx="11" fill="url(#accent)" opacity="0.7"/>
+  <text x="300" y="317" font-family="sans-serif" font-size="10" fill="white" text-anchor="middle">Book Now</text>
+
+  <rect x="400" y="160" width="165" height="180" rx="14" fill="#ffffff08" stroke="#eab30820" stroke-width="1"/>
+  <rect x="400" y="160" width="165" height="80" rx="14" fill="#eab30812"/>
+  <rect x="400" y="220" width="165" height="20" rx="0" fill="#eab30812"/>
+  <text x="428" y="216" font-family="sans-serif" font-size="10" fill="#94a3b8">📍 Delhi, DL</text>
+  <text x="415" y="252" font-family="sans-serif" font-size="11" font-weight="bold" fill="#f1f5f9">Spice Garden Catering</text>
+  <text x="415" y="268" font-family="sans-serif" font-size="10" fill="#94a3b8">Caterer · ₹650/plate</text>
+  <rect x="415" y="278" width="60" height="14" rx="7" fill="#eab30820"/>
+  <text x="445" y="289" font-family="sans-serif" font-size="9" fill="#eab308" text-anchor="middle">★ 4.9</text>
+  <rect x="415" y="302" width="130" height="22" rx="11" fill="url(#accent)" opacity="0.7"/>
+  <text x="480" y="317" font-family="sans-serif" font-size="10" fill="white" text-anchor="middle">Book Now</text>
+
+  <rect x="580" y="160" width="165" height="180" rx="14" fill="#ffffff08" stroke="#eab30820" stroke-width="1"/>
+  <rect x="580" y="160" width="165" height="80" rx="14" fill="#f9731612"/>
+  <rect x="580" y="220" width="165" height="20" rx="0" fill="#f9731612"/>
+  <text x="608" y="216" font-family="sans-serif" font-size="10" fill="#94a3b8">📍 Bangalore, KA</text>
+  <text x="595" y="252" font-family="sans-serif" font-size="11" font-weight="bold" fill="#f1f5f9">LensArt Photography</text>
+  <text x="595" y="268" font-family="sans-serif" font-size="10" fill="#94a3b8">Photographer · ₹25,000</text>
+  <rect x="595" y="278" width="60" height="14" rx="7" fill="#f9731620"/>
+  <text x="625" y="289" font-family="sans-serif" font-size="9" fill="#f97316" text-anchor="middle">★ 4.7</text>
+  <rect x="595" y="302" width="130" height="22" rx="11" fill="url(#accent)" opacity="0.7"/>
+  <text x="660" y="317" font-family="sans-serif" font-size="10" fill="white" text-anchor="middle">Book Now</text>
+
+  <!-- Bottom bar -->
+  <rect x="40" y="362" width="720" height="56" rx="12" fill="#ffffff06" stroke="#eab30815" stroke-width="1"/>
+  <text x="80" y="385" font-family="sans-serif" font-size="10" fill="#94a3b8">Vendors Listed</text>
+  <text x="80" y="403" font-family="sans-serif" font-size="16" font-weight="bold" fill="#eab308">5,000+</text>
+  <text x="280" y="385" font-family="sans-serif" font-size="10" fill="#94a3b8">Events Planned</text>
+  <text x="280" y="403" font-family="sans-serif" font-size="16" font-weight="bold" fill="#f97316">12,000+</text>
+  <text x="480" y="385" font-family="sans-serif" font-size="10" fill="#94a3b8">Cities</text>
+  <text x="480" y="403" font-family="sans-serif" font-size="16" font-weight="bold" fill="#eab308">50+</text>
+  <text x="630" y="385" font-family="sans-serif" font-size="10" fill="#94a3b8">Platform</text>
+  <text x="630" y="403" font-family="sans-serif" font-size="14" font-weight="bold" fill="#f97316">OppVenuz</text>
+</svg>


### PR DESCRIPTION
## Summary

### Projects restructure
- **Swapped PeriopMD → Balajee ERP** in the main 4-card grid
- **OppVenuz** added to the "See More" modal (event planning marketplace connecting users with vendors — venues, caterers, decorators, photographers — available on web, iOS, and Android)
- PeriopMD moved to the modal alongside Edunaa and OppVenuz
- Custom SVG placeholder image created for OppVenuz

### GitHub Activity enhancements
- **4 animated stat pills** at the top: Public Repos, Total Stars, Followers, Total Forks (fetched live from GitHub API at build time)
- **GitHub Stats card** — total commits, PRs, issues, and contribution counts (github-readme-stats)
- **Top Languages card** — language breakdown across all repos
- **GitHub Streak Stats card** — current streak, longest streak, total contributions (streak-stats.demolab.com)
- **Upgraded contribution chart** — replaced basic ghchart with the nicer `github-activity-graph` (area fill, indigo theme)

## Test plan
- [ ] Main projects grid shows: WellPro, Balajee ERP, TTA Connect, Trabus RippleGo
- [ ] "See More" modal shows: OppVenuz, PeriopMD, Edunaa
- [ ] GitHub Activity section shows 4 stat pills with real numbers
- [ ] GitHub Stats, Top Languages, and Streak cards render correctly
- [ ] Contribution activity graph renders with indigo colour theme

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_