### PR TITLE
Fix dark mode white background on GitHub stats cards + PDF improvements

### DIFF
--- a/components/GitHubActivity.tsx
+++ b/components/GitHubActivity.tsx
@@ -60,7 +60,8 @@ async function fetchProfile(): Promise<GitHubProfile | null> {
 }
 
 const GRS = 'https://github-readme-stats-surajfc.vercel.app/api'
-const GRS_PARAMS = 'theme=swift&hide_border=false&include_all_commits=true&count_private=true&show_icons=true&cache_seconds=1800'
+const GRS_LIGHT = 'theme=swift&hide_border=false&include_all_commits=true&count_private=true&show_icons=true&cache_seconds=1800'
+const GRS_DARK  = 'theme=transparent&hide_border=true&title_color=818cf8&icon_color=818cf8&text_color=94a3b8&bg_color=00000000&include_all_commits=true&count_private=true&show_icons=true&cache_seconds=1800'
 
 export default async function GitHubActivity() {
   const [repos, profile] = await Promise.all([fetchRepos(), fetchProfile()])
@@ -86,35 +87,28 @@ export default async function GitHubActivity() {
 
         {/* GitHub Stats + Top Languages (self-hosted instance) */}
         <div className="grid md:grid-cols-2 gap-4 mb-4">
-          <div className="p-2 rounded-xl bg-white border border-black/10 flex items-center justify-center overflow-hidden">
+          {/* Stats card */}
+          <div className="rounded-xl border border-black/10 dark:border-white/10 overflow-hidden bg-white dark:bg-transparent flex items-center justify-center p-2">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={`${GRS}?username=SurajFc&${GRS_PARAMS}`}
-              alt="Suraj's GitHub stats"
-              className="w-full"
-              loading="lazy"
-            />
+            <img src={`${GRS}?username=SurajFc&${GRS_LIGHT}`} alt="Suraj's GitHub stats" className="w-full block dark:hidden" loading="lazy" />
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={`${GRS}?username=SurajFc&${GRS_DARK}`}  alt="Suraj's GitHub stats" className="w-full hidden dark:block" loading="lazy" />
           </div>
-          <div className="p-2 rounded-xl bg-white border border-black/10 flex items-center justify-center overflow-hidden">
+          {/* Top Languages card */}
+          <div className="rounded-xl border border-black/10 dark:border-white/10 overflow-hidden bg-white dark:bg-transparent flex items-center justify-center p-2">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={`${GRS}/top-langs/?username=SurajFc&theme=swift&hide_border=false&layout=compact&langs_count=10&cache_seconds=1800`}
-              alt="Suraj's top languages"
-              className="w-full"
-              loading="lazy"
-            />
+            <img src={`${GRS}/top-langs/?username=SurajFc&theme=swift&hide_border=false&layout=compact&langs_count=10&cache_seconds=1800`}            alt="Suraj's top languages" className="w-full block dark:hidden" loading="lazy" />
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={`${GRS}/top-langs/?username=SurajFc&theme=transparent&hide_border=true&title_color=818cf8&text_color=94a3b8&bg_color=00000000&layout=compact&langs_count=10&cache_seconds=1800`} alt="Suraj's top languages" className="w-full hidden dark:block" loading="lazy" />
           </div>
         </div>
 
         {/* Streak Stats */}
-        <div className="p-2 rounded-xl bg-white border border-black/10 flex items-center justify-center overflow-hidden mb-10">
+        <div className="rounded-xl border border-black/10 dark:border-white/10 overflow-hidden bg-white dark:bg-transparent flex items-center justify-center p-2 mb-10">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="https://streak-stats.demolab.com/?user=SurajFc&theme=swift&hide_border=false"
-            alt="Suraj's GitHub streak stats"
-            className="w-full max-w-2xl"
-            loading="lazy"
-          />
+          <img src="https://streak-stats.demolab.com/?user=SurajFc&theme=swift&hide_border=false"       alt="Suraj's GitHub streak stats" className="w-full max-w-2xl block dark:hidden" loading="lazy" />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="https://streak-stats.demolab.com/?user=SurajFc&theme=transparent&hide_border=true&stroke=818cf8&ring=818cf8&fire=f97316&currStreakNum=94a3b8&sideNums=94a3b8&currStreakLabel=818cf8&sideLabels=64748b&dates=64748b&background=00000000" alt="Suraj's GitHub streak stats" className="w-full max-w-2xl hidden dark:block" loading="lazy" />
         </div>
 
         {/* Pinned repo cards */}

--- a/components/GitHubActivity.tsx
+++ b/components/GitHubActivity.tsx
@@ -1,6 +1,7 @@
 import SectionHeading from './SectionHeading'
 import RepoCards from './RepoCards'
 import GitHubStatPills from './GitHubStatPills'
+import GitHubNativeStats, { type LangStat } from './GitHubNativeStats'
 import { FaGithub } from 'react-icons/fa'
 
 interface Repo {
@@ -31,7 +32,7 @@ const PINNED_REPOS = [
 
 const GH_HEADERS = { Accept: 'application/vnd.github+json' }
 
-async function fetchRepos(): Promise<Repo[]> {
+async function fetchPinnedRepos(): Promise<Repo[]> {
   try {
     const results = await Promise.all(
       PINNED_REPOS.map((name) =>
@@ -42,6 +43,18 @@ async function fetchRepos(): Promise<Repo[]> {
       )
     )
     return results.filter(Boolean) as Repo[]
+  } catch {
+    return []
+  }
+}
+
+async function fetchAllRepos(): Promise<Repo[]> {
+  try {
+    const r = await fetch(
+      'https://api.github.com/users/SurajFc/repos?per_page=100&type=owner&sort=updated',
+      { headers: GH_HEADERS, cache: 'force-cache' }
+    )
+    return r.ok ? (r.json() as Promise<Repo[]>) : []
   } catch {
     return []
   }
@@ -59,16 +72,31 @@ async function fetchProfile(): Promise<GitHubProfile | null> {
   }
 }
 
-// Self-hosted github-readme-stats instance (avoids public rate limits)
-const GRS_BASE = 'https://github-readme-stats-surajfc.vercel.app/api'
-const GRS_PARAMS = 'theme=swift&hide_border=false&include_all_commits=true&count_private=true&show_icons=true&cache_seconds=1800'
+function computeLanguages(repos: Repo[]): LangStat[] {
+  const counts: Record<string, number> = {}
+  for (const repo of repos) {
+    if (repo.language) counts[repo.language] = (counts[repo.language] ?? 0) + 1
+  }
+  const total = Object.values(counts).reduce((a, b) => a + b, 0)
+  if (total === 0) return []
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([name, count]) => ({ name, percent: Math.round((count / total) * 100) }))
+}
 
 export default async function GitHubActivity() {
-  const [repos, profile] = await Promise.all([fetchRepos(), fetchProfile()])
-  if (repos.length === 0) return null
+  const [pinnedRepos, allRepos, profile] = await Promise.all([
+    fetchPinnedRepos(),
+    fetchAllRepos(),
+    fetchProfile(),
+  ])
 
-  const totalStars = repos.reduce((acc, r) => acc + r.stargazers_count, 0)
-  const totalForks = repos.reduce((acc, r) => acc + r.forks_count, 0)
+  if (pinnedRepos.length === 0) return null
+
+  const totalStars = allRepos.reduce((acc, r) => acc + r.stargazers_count, 0)
+  const totalForks = allRepos.reduce((acc, r) => acc + r.forks_count, 0)
+  const languages  = computeLanguages(allRepos)
 
   return (
     <section className="py-24 px-4 bg-black/[0.02] dark:bg-white/[0.02]">
@@ -79,35 +107,22 @@ export default async function GitHubActivity() {
 
         {/* Live stat pills */}
         <GitHubStatPills
-          publicRepos={profile?.public_repos ?? repos.length}
+          publicRepos={profile?.public_repos ?? pinnedRepos.length}
           totalStars={totalStars}
           followers={profile?.followers ?? 0}
           totalForks={totalForks}
         />
 
-        {/* GitHub Stats + Top Languages */}
-        <div className="grid md:grid-cols-2 gap-4 mb-4">
-          <div className="p-2 rounded-xl bg-white border border-black/10 flex items-center justify-center overflow-hidden">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={`${GRS_BASE}?username=SurajFc&${GRS_PARAMS}`}
-              alt="Suraj's GitHub stats"
-              className="w-full max-w-sm"
-              loading="lazy"
-            />
-          </div>
-          <div className="p-2 rounded-xl bg-white border border-black/10 flex items-center justify-center overflow-hidden">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={`${GRS_BASE}/top-langs/?username=SurajFc&theme=swift&hide_border=false&layout=compact&langs_count=10&cache_seconds=1800`}
-              alt="Suraj's top languages"
-              className="w-full max-w-sm"
-              loading="lazy"
-            />
-          </div>
-        </div>
+        {/* Native GitHub Stats + Top Languages cards */}
+        <GitHubNativeStats
+          totalStars={totalStars}
+          totalForks={totalForks}
+          publicRepos={profile?.public_repos ?? allRepos.length}
+          followers={profile?.followers ?? 0}
+          languages={languages}
+        />
 
-        {/* Streak Stats */}
+        {/* Streak Stats (needs auth for native — keeping the image) */}
         <div className="p-2 rounded-xl bg-white border border-black/10 flex items-center justify-center overflow-hidden mb-10">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
@@ -119,7 +134,7 @@ export default async function GitHubActivity() {
         </div>
 
         {/* Pinned repo cards */}
-        <RepoCards repos={repos} />
+        <RepoCards repos={pinnedRepos} />
 
         {/* Contribution activity graph */}
         <div className="mt-10 p-4 rounded-xl bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 overflow-hidden">

--- a/components/GitHubActivity.tsx
+++ b/components/GitHubActivity.tsx
@@ -1,7 +1,6 @@
 import SectionHeading from './SectionHeading'
 import RepoCards from './RepoCards'
 import GitHubStatPills from './GitHubStatPills'
-import GitHubNativeStats, { type LangStat } from './GitHubNativeStats'
 import { FaGithub } from 'react-icons/fa'
 
 interface Repo {
@@ -32,7 +31,7 @@ const PINNED_REPOS = [
 
 const GH_HEADERS = { Accept: 'application/vnd.github+json' }
 
-async function fetchPinnedRepos(): Promise<Repo[]> {
+async function fetchRepos(): Promise<Repo[]> {
   try {
     const results = await Promise.all(
       PINNED_REPOS.map((name) =>
@@ -43,18 +42,6 @@ async function fetchPinnedRepos(): Promise<Repo[]> {
       )
     )
     return results.filter(Boolean) as Repo[]
-  } catch {
-    return []
-  }
-}
-
-async function fetchAllRepos(): Promise<Repo[]> {
-  try {
-    const r = await fetch(
-      'https://api.github.com/users/SurajFc/repos?per_page=100&type=owner&sort=updated',
-      { headers: GH_HEADERS, cache: 'force-cache' }
-    )
-    return r.ok ? (r.json() as Promise<Repo[]>) : []
   } catch {
     return []
   }
@@ -72,31 +59,15 @@ async function fetchProfile(): Promise<GitHubProfile | null> {
   }
 }
 
-function computeLanguages(repos: Repo[]): LangStat[] {
-  const counts: Record<string, number> = {}
-  for (const repo of repos) {
-    if (repo.language) counts[repo.language] = (counts[repo.language] ?? 0) + 1
-  }
-  const total = Object.values(counts).reduce((a, b) => a + b, 0)
-  if (total === 0) return []
-  return Object.entries(counts)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 8)
-    .map(([name, count]) => ({ name, percent: Math.round((count / total) * 100) }))
-}
+const GRS = 'https://github-readme-stats-surajfc.vercel.app/api'
+const GRS_PARAMS = 'theme=swift&hide_border=false&include_all_commits=true&count_private=true&show_icons=true&cache_seconds=1800'
 
 export default async function GitHubActivity() {
-  const [pinnedRepos, allRepos, profile] = await Promise.all([
-    fetchPinnedRepos(),
-    fetchAllRepos(),
-    fetchProfile(),
-  ])
+  const [repos, profile] = await Promise.all([fetchRepos(), fetchProfile()])
+  if (repos.length === 0) return null
 
-  if (pinnedRepos.length === 0) return null
-
-  const totalStars = allRepos.reduce((acc, r) => acc + r.stargazers_count, 0)
-  const totalForks = allRepos.reduce((acc, r) => acc + r.forks_count, 0)
-  const languages  = computeLanguages(allRepos)
+  const totalStars = repos.reduce((acc, r) => acc + r.stargazers_count, 0)
+  const totalForks = repos.reduce((acc, r) => acc + r.forks_count, 0)
 
   return (
     <section className="py-24 px-4 bg-black/[0.02] dark:bg-white/[0.02]">
@@ -107,22 +78,35 @@ export default async function GitHubActivity() {
 
         {/* Live stat pills */}
         <GitHubStatPills
-          publicRepos={profile?.public_repos ?? pinnedRepos.length}
+          publicRepos={profile?.public_repos ?? repos.length}
           totalStars={totalStars}
           followers={profile?.followers ?? 0}
           totalForks={totalForks}
         />
 
-        {/* Native GitHub Stats + Top Languages cards */}
-        <GitHubNativeStats
-          totalStars={totalStars}
-          totalForks={totalForks}
-          publicRepos={profile?.public_repos ?? allRepos.length}
-          followers={profile?.followers ?? 0}
-          languages={languages}
-        />
+        {/* GitHub Stats + Top Languages (self-hosted instance) */}
+        <div className="grid md:grid-cols-2 gap-4 mb-4">
+          <div className="p-2 rounded-xl bg-white border border-black/10 flex items-center justify-center overflow-hidden">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`${GRS}?username=SurajFc&${GRS_PARAMS}`}
+              alt="Suraj's GitHub stats"
+              className="w-full"
+              loading="lazy"
+            />
+          </div>
+          <div className="p-2 rounded-xl bg-white border border-black/10 flex items-center justify-center overflow-hidden">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`${GRS}/top-langs/?username=SurajFc&theme=swift&hide_border=false&layout=compact&langs_count=10&cache_seconds=1800`}
+              alt="Suraj's top languages"
+              className="w-full"
+              loading="lazy"
+            />
+          </div>
+        </div>
 
-        {/* Streak Stats (needs auth for native — keeping the image) */}
+        {/* Streak Stats */}
         <div className="p-2 rounded-xl bg-white border border-black/10 flex items-center justify-center overflow-hidden mb-10">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
@@ -134,7 +118,7 @@ export default async function GitHubActivity() {
         </div>
 
         {/* Pinned repo cards */}
-        <RepoCards repos={pinnedRepos} />
+        <RepoCards repos={repos} />
 
         {/* Contribution activity graph */}
         <div className="mt-10 p-4 rounded-xl bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 overflow-hidden">

--- a/components/GitHubNativeStats.tsx
+++ b/components/GitHubNativeStats.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { FaStar, FaCodeBranch, FaGithub, FaUsers } from 'react-icons/fa'
+
+const LANG_COLORS: Record<string, string> = {
+  TypeScript:  '#3178c6',
+  JavaScript:  '#f1e05a',
+  Python:      '#3572A5',
+  CSS:         '#563d7c',
+  HTML:        '#e34c26',
+  Vue:         '#41b883',
+  Dart:        '#00B4AB',
+  Shell:       '#89e051',
+  SCSS:        '#c6538c',
+  Kotlin:      '#A97BFF',
+  Swift:       '#F05138',
+  Go:          '#00ADD8',
+  Rust:        '#dea584',
+  Java:        '#b07219',
+}
+
+export interface LangStat { name: string; percent: number }
+
+interface Props {
+  totalStars: number
+  totalForks: number
+  publicRepos: number
+  followers: number
+  languages: LangStat[]
+}
+
+export default function GitHubNativeStats({ totalStars, totalForks, publicRepos, followers, languages }: Props) {
+  const statItems = [
+    { icon: FaStar,       label: 'Total Stars',   value: totalStars,   color: 'text-yellow-400' },
+    { icon: FaCodeBranch, label: 'Total Forks',   value: totalForks,   color: 'text-purple-400' },
+    { icon: FaGithub,     label: 'Public Repos',  value: publicRepos,  color: 'text-indigo-400' },
+    { icon: FaUsers,      label: 'Followers',     value: followers,    color: 'text-emerald-400' },
+  ]
+
+  return (
+    <div className="grid md:grid-cols-2 gap-4 mb-4">
+      {/* GitHub Stats */}
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10"
+      >
+        <p className="text-xs font-semibold text-indigo-500 dark:text-indigo-400 uppercase tracking-widest mb-4">
+          GitHub Stats
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          {statItems.map(({ icon: Icon, label, value, color }, i) => (
+            <motion.div
+              key={label}
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.3, delay: 0.1 + i * 0.06 }}
+              className="flex items-center gap-3 p-3 rounded-lg bg-black/[0.02] dark:bg-white/[0.03] border border-black/5 dark:border-white/5"
+            >
+              <Icon className={`text-lg flex-shrink-0 ${color}`} />
+              <div>
+                <p className="text-lg font-bold text-slate-900 dark:text-white tabular-nums leading-tight">{value}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </motion.div>
+
+      {/* Top Languages */}
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.1 }}
+        className="p-5 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10"
+      >
+        <p className="text-xs font-semibold text-indigo-500 dark:text-indigo-400 uppercase tracking-widest mb-4">
+          Top Languages
+        </p>
+
+        {/* Segmented rainbow bar */}
+        <div className="flex h-2 rounded-full overflow-hidden mb-5 gap-px">
+          {languages.map((lang) => (
+            <motion.div
+              key={lang.name}
+              initial={{ width: 0 }}
+              animate={{ width: `${lang.percent}%` }}
+              transition={{ duration: 0.7, ease: 'easeOut' }}
+              style={{ backgroundColor: LANG_COLORS[lang.name] ?? '#6366f1' }}
+              title={`${lang.name}: ${lang.percent}%`}
+            />
+          ))}
+        </div>
+
+        <div className="space-y-2.5">
+          {languages.map((lang, i) => (
+            <div key={lang.name} className="flex items-center gap-2.5">
+              <span
+                className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: LANG_COLORS[lang.name] ?? '#6366f1' }}
+              />
+              <span className="text-sm text-slate-700 dark:text-slate-300 w-24 truncate">{lang.name}</span>
+              <div className="flex-1 h-1.5 rounded-full bg-black/10 dark:bg-white/10 overflow-hidden">
+                <motion.div
+                  initial={{ width: 0 }}
+                  animate={{ width: `${lang.percent}%` }}
+                  transition={{ duration: 0.6, delay: 0.25 + i * 0.05, ease: 'easeOut' }}
+                  className="h-full rounded-full"
+                  style={{ backgroundColor: LANG_COLORS[lang.name] ?? '#6366f1' }}
+                />
+              </div>
+              <span className="text-xs text-slate-500 dark:text-slate-400 tabular-nums w-8 text-right">
+                {lang.percent}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/lib/generateResumePdf.tsx
+++ b/lib/generateResumePdf.tsx
@@ -86,6 +86,7 @@ const s = StyleSheet.create({
   projectName:  { fontSize: 9.2, fontFamily: 'Helvetica-Bold', color: HEADING },
   projectTech:  { fontSize: 7.8, color: ACCENT, marginTop: 1, fontFamily: 'Helvetica-Oblique' },
   projectDesc:  { color: BODY, marginTop: 1.5, fontSize: 8.5 },
+  seeMore:      { fontSize: 8, color: ACCENT, marginTop: 4, fontFamily: 'Helvetica-Oblique' },
 
   /* ── Sidebar items ───────────────────────────────────── */
   skillBlock:   { marginBottom: 4 },
@@ -212,6 +213,9 @@ export function ResumeDocument() {
                   </View>
                 ))}
               </View>
+              <Link src="https://surajthapa.vercel.app/#projects" style={s.seeMore}>
+                See more projects → surajthapa.vercel.app
+              </Link>
             </Section>
           </View>
         </View>

--- a/lib/resume.ts
+++ b/lib/resume.ts
@@ -10,7 +10,7 @@ export const resumeData = {
     github: 'github.com/SurajFc',
     linkedin: 'linkedin.com/in/suraj4',
     stackoverflow: 'stackoverflow.com/users/12359814/surajfc',
-    portfolio: 'surajfc.github.io/surajPortfolio',
+    portfolio: 'surajthapa.vercel.app',
   },
   summary:
     'Versatile software engineer with 5+ years of industry experience, having successfully delivered complex technical projects across front-end and back-end development. A collaborative team member and effective problem solver seeking to contribute to a challenging environment.',


### PR DESCRIPTION
## Summary

### GitHub Stats cards — dark mode fix
- Each stats card (GitHub Stats, Top Languages, Streak) now serves two images: `theme=swift` for light mode and `theme=transparent` with indigo/slate colours for dark mode
- CSS `block dark:hidden` / `hidden dark:block` toggles between them — no JS needed
- Card wrappers use `bg-white` in light / `bg-transparent` in dark so no white box appears in dark mode

### Resume PDF improvements
- Added a clickable **"See more projects → surajthapa.vercel.app"** link at the bottom of the Projects section in the downloaded CV
- Updated the portfolio URL in the CV contact header from the old GitHub Pages address to `surajthapa.vercel.app`

## Test plan
- [ ] Dark mode: stats cards show transparent/indigo-themed images with no white background
- [ ] Light mode: stats cards still show the clean `swift` theme
- [ ] Download CV → Projects section has a clickable "See more projects" link
- [ ] CV contact header shows `surajthapa.vercel.app`

https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhCKKTs3osc5u4cs8h67S2)_